### PR TITLE
Work around to ignore prettier syntax errors

### DIFF
--- a/src/formatters.ts
+++ b/src/formatters.ts
@@ -29,10 +29,14 @@ export const cliFormatters: { [filename: string]: CLIFormatter } = {
 
 // deno-lint-ignore require-await
 async function formatJsTs(source: string): Promise<string> {
-  return prettier.format(source, {
-    parser: "typescript",
-    plugins: prettierPlugins,
-  });
+  try {
+    return prettier.format(source, {
+      parser: "typescript",
+      plugins: prettierPlugins,
+    });
+  } catch (_e) {
+    return source;
+  }
 }
 
 const astyleHref = new URL("./astyle.wasm", import.meta.url).href;


### PR DESCRIPTION
This PR skips formatting TypeScript files when there are syntax errors.
We will need to find a way to use a more recent prettier, or perhaps use `deno fmt`.