### PR TITLE
Templates: Do not prompt for provided variables

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,7 +1,7 @@
 import { Command } from "https://deno.land/x/cliffy@v0.25.5/command/mod.ts";
 
 import { Variables } from "../config.ts";
-import { initializeProject, TemplateOptions } from "../init.ts";
+import { initializeProject } from "../init.ts";
 import { templateCompletion, varOptions } from "./utils.ts";
 
 export const command = new Command()

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -1,7 +1,7 @@
 import { Command } from "https://deno.land/x/cliffy@v0.25.5/command/mod.ts";
 
 import { Variables } from "../config.ts";
-import { initializeProject, TemplateOptions } from "../init.ts";
+import { initializeProject } from "../init.ts";
 import { templateCompletion, varOptions } from "./utils.ts";
 
 export const command = new Command()

--- a/src/init.ts
+++ b/src/init.ts
@@ -31,9 +31,11 @@ export async function initializeProject(
   for (const generated of outputs) {
     let exists = false;
     try {
-      const stat = await Deno.stat(generated.path);
+      const _stat = await Deno.stat(generated.path);
       exists = true;
-    } catch {}
+    } catch (_e) {
+      // Ignore
+    }
     if (exists && !options.isNew) {
       log.debug(`Skipping ${generated.path} as it already exists`);
       continue;

--- a/src/process.ts
+++ b/src/process.ts
@@ -43,6 +43,7 @@ export async function process(config: Configuration): Promise<Output[]> {
   const output = new TextDecoder().decode(rawOutput);
   log.debug(`Generator output: ${output}`);
   const fromJson = JSON.parse(output) as JsonOutput[];
+  // deno-lint-ignore no-explicit-any
   const parsedOutput = fromJson.map((o: any) => {
     o.contents = Uint8Array.from(o.contents);
     return o as Output;

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -59,9 +59,11 @@ Deno.test(
       required: true,
       loop: false,
     }];
-    const variables = {};
+    const variables = {
+      module: "I am provided",
+    };
     const unresolved = getUnresolved(variables, definitions);
-    assertEquals(variables, { "module": "default value" });
+    assertEquals(variables, { "module": "I am provided" });
     assertEquals(unresolved, [{
       name: "needed",
       description: "a required var",

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -1,8 +1,7 @@
-import * as apex from "https://deno.land/x/apex_core@v0.1.1/mod.ts";
 import { assertEquals } from "https://deno.land/std@0.167.0/testing/asserts.ts";
-import { getTemplateSources, mergeVariables } from "../src/init.ts";
+import { getTemplateSources, getUnresolved } from "../src/init.ts";
 import * as path from "https://deno.land/std@0.167.0/path/mod.ts";
-import { asBytes, asString, setupLogger } from "../src/utils.ts";
+import { asBytes, setupLogger } from "../src/utils.ts";
 import { Variable } from "../src/config.ts";
 
 const __dirname = new URL(".", import.meta.url).pathname;
@@ -61,7 +60,7 @@ Deno.test(
       loop: false,
     }];
     const variables = {};
-    const unresolved = mergeVariables(variables, definitions);
+    const unresolved = getUnresolved(variables, definitions);
     assertEquals(variables, { "module": "default value" });
     assertEquals(unresolved, [{
       name: "needed",


### PR DESCRIPTION
This PR fixes not prompting the user for variables provided on the command line using `--var [name]=[value]`.