### PR TITLE
Programmable templates, task runner, appending visitors, rendering imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,19 @@
 # Apex CLI
 
-Apex is an interface definition language (IDL) for modeling software. Generate source code, documentation, integration, everything automatically.
+Apex is an interface definition language (IDL) for modeling software. Generate
+source code, documentation, integration, everything automatically.
 
 ### Goals:
 
-- <ins>A</ins>pproachable - Apex was designed from the ground up to be succinct. Interfaces and data types are described using familiar syntax that won't slow you down.
-- <ins>P</ins>rotocol agnostic - Regardless of the architecture, your data and interfaces are fundamentally the same. Use Apex to generate code for any serialization format or protocol.
-- <ins>Ex</ins>tensible - Generators are written in TypeScript. Easily add custom generators that satisfy your unique needs and publish them for everyone to use.
+- <ins>A</ins>pproachable - Apex was designed from the ground up to be succinct.
+  Interfaces and data types are described using familiar syntax that won't slow
+  you down.
+- <ins>P</ins>rotocol agnostic - Regardless of the architecture, your data and
+  interfaces are fundamentally the same. Use Apex to generate code for any
+  serialization format or protocol.
+- <ins>Ex</ins>tensible - Generators are written in TypeScript. Easily add
+  custom generators that satisfy your unique needs and publish them for everyone
+  to use.
 
 For more information, visit [https://apexlang.io](https://apexlang.io).
 
@@ -28,7 +35,7 @@ Output:
 
 ```
   Usage:   apex
-  Version: 0.0.2
+  Version: v0.0.12
 
   Description:
 
@@ -36,15 +43,19 @@ Output:
 
   Options:
 
-    -h, --help  - Show this help.
+    -h, --help     - Show this help.
+    -V, --version  - Show the version number for this program.
 
   Commands:
 
+    install      <location>          - Install templates locally.
     new          <template> <dir>    - Create a new project directory using a template.
     init         <template>          - Initialize a project using a template.
     generate     [configuration...]  - Run apex generators from a given configuration.
     list                             - List available resources.
+    describe                         - Describe available resources.
     watch        [configuration...]  - Watch apex configuration for changes and trigger code generation.
+    run          [tasks...]          - Run tasks.
     upgrade                          - Upgrade apex executable to latest or given version.
     help         [command]           - Show this help or the help of a sub-command.
     completions                      - Generate shell completions.
@@ -52,12 +63,18 @@ Output:
 
 ## Contributing
 
-Please read [CONTRIBUTING.md](https://github.com/apexlang/apex/blob/main/CONTRIBUTING.md) for details on our code of conduct, and the process for submitting pull requests to us.
+Please read
+[CONTRIBUTING.md](https://github.com/apexlang/apex/blob/main/CONTRIBUTING.md)
+for details on our code of conduct, and the process for submitting pull requests
+to us.
 
 ## Versioning
 
-We use [SemVer](http://semver.org/) for versioning. For the versions available, see the [tags on this repository](https://github.com/apexlang/apex/tags).
+We use [SemVer](http://semver.org/) for versioning. For the versions available,
+see the [tags on this repository](https://github.com/apexlang/apex/tags).
 
 ## License
 
-This project is licensed under the [Apache License 2.0](https://choosealicense.com/licenses/apache-2.0/) - see the [LICENSE](LICENSE) file for details
+This project is licensed under the
+[Apache License 2.0](https://choosealicense.com/licenses/apache-2.0/) - see the
+[LICENSE](LICENSE) file for details

--- a/apex.ts
+++ b/apex.ts
@@ -25,7 +25,7 @@ import * as list from "./src/commands/list.ts";
 import * as describe from "./src/commands/describe.ts";
 import * as watch from "./src/commands/watch.ts";
 import * as run from "./src/commands/run.ts";
-import { setupLogger } from "./src/utils.ts";
+import { findApexConfig, setupLogger } from "./src/utils.ts";
 
 // Version bump this on release.
 const version = "v0.0.11";
@@ -74,9 +74,14 @@ if (
 
   // Run target if defined in the config.
   if (args.length > 0 && !cli.getBaseCommand(args[0], true)) {
-    const targetMap = await run.loadTasks("apex.yaml");
+    const configFile = findApexConfig();
+    if (!configFile) {
+      console.log("could not find configuration");
+      Deno.exit(1);
+    }
+    const targetMap = await run.loadTasks(configFile);
     if (targetMap[args[0]]) {
-      await run.runTasks("apex.yaml", targetMap, args);
+      await run.runTasks(configFile, targetMap, args);
       Deno.exit(0);
     }
   }

--- a/apex.ts
+++ b/apex.ts
@@ -9,7 +9,7 @@ import {
   GithubProvider,
   UpgradeCommand,
 } from "https://deno.land/x/cliffy@v0.25.5/command/upgrade/mod.ts";
-import * as log from "https://deno.land/std@0.167.0/log/mod.ts";
+import * as log from "https://deno.land/std@0.171.0/log/mod.ts";
 
 const LEVEL =
   (Deno.env.get("APEX_LOG")?.toUpperCase() as log.LevelName | undefined) ||
@@ -19,33 +19,41 @@ await setupLogger(LEVEL);
 
 import * as generate from "./src/commands/generate.ts";
 import * as newCmd from "./src/commands/new.ts";
+import * as install from "./src/commands/install.ts";
 import * as init from "./src/commands/init.ts";
 import * as list from "./src/commands/list.ts";
+import * as describe from "./src/commands/describe.ts";
 import * as watch from "./src/commands/watch.ts";
+import * as run from "./src/commands/run.ts";
 import { setupLogger } from "./src/utils.ts";
 
 // Version bump this on release.
 const version = "v0.0.11";
 
+const args = Deno.args;
+
 if (
-  Deno.args.length == 1 &&
-  Deno.args[0] == "__generate" &&
+  args.length == 1 &&
+  args[0] == "__generate" &&
   !Deno.isatty(Deno.stdin.rid)
 ) {
   generate.fromStdin();
 } else {
-  await new Command()
+  const cli = new Command()
     .default("help")
     .version(version)
     .name("apex")
     .description(
       "A code generation tool using Apex, an interface definition language (IDL) for modeling software.",
     )
+    .command("install", install.command)
     .command("new", newCmd.command)
     .command("init", init.command)
     .command("generate", generate.command)
     .command("list", list.command)
+    .command("describe", describe.command)
     .command("watch", watch.command)
+    .command("run", run.command)
     .command(
       "upgrade",
       new UpgradeCommand({
@@ -62,6 +70,16 @@ if (
       }),
     )
     .command("help", new HelpCommand().global())
-    .command("completions", new CompletionsCommand())
-    .parse(Deno.args);
+    .command("completions", new CompletionsCommand());
+
+  // Run target if defined in the config.
+  if (args.length > 0 && !cli.getBaseCommand(args[0], true)) {
+    const targetMap = await run.loadTasks("apex.yaml");
+    if (targetMap[args[0]]) {
+      await run.runTasks("apex.yaml", targetMap, args);
+      Deno.exit(0);
+    }
+  }
+
+  await cli.parse(args);
 }

--- a/apex.ts
+++ b/apex.ts
@@ -28,7 +28,7 @@ import * as run from "./src/commands/run.ts";
 import { findApexConfig, setupLogger } from "./src/utils.ts";
 
 // Version bump this on release.
-const version = "v0.0.11";
+const version = "v0.0.12";
 
 const args = Deno.args;
 
@@ -73,7 +73,9 @@ if (
     .command("completions", new CompletionsCommand());
 
   // Run target if defined in the config.
-  if (args.length > 0 && !cli.getBaseCommand(args[0], true)) {
+  const nonFlagArgs = args.filter((v) => !v.startsWith("-"));
+  if (nonFlagArgs.length > 0 && !cli.getBaseCommand(args[0], true)) {
+    console.log(args);
     const configFile = findApexConfig();
     if (!configFile) {
       console.log("could not find configuration");

--- a/justfile
+++ b/justfile
@@ -1,6 +1,6 @@
 test:
   deno fmt --check src/ test/
-  deno test --unstable -A test/init.test.ts
+  deno test --unstable -A test/*.test.ts
 
 install:
   deno install -f -A --unstable ./apex.ts

--- a/src/asset_builder.ts
+++ b/src/asset_builder.ts
@@ -1,0 +1,54 @@
+import * as cache from "./cache.ts";
+import { Assets } from "./config.ts";
+
+export class AssetsBuilder {
+  private baseURL: string | URL;
+  private _assets: Assets;
+
+  constructor(baseURL: string | URL) {
+    this.baseURL = baseURL;
+    this._assets = {};
+  }
+
+  async addFiles(...paths: string[]) {
+    for (let path of paths) {
+      if (path.indexOf("..") != -1) {
+        throw new Error(`invalid path ${path}`);
+      }
+      if (path.startsWith("./")) {
+        path = "./" + path;
+      }
+      const u = new URL(path, this.baseURL);
+      const data = await cache.load(u.toString());
+      this._assets[path] = data;
+    }
+  }
+
+  async addTemplates(
+    render: (temp: string) => Promise<string>,
+    ...paths: string[]
+  ) {
+    for (let path of paths) {
+      if (path.indexOf("..") != -1) {
+        throw new Error(`invalid path ${path}`);
+      }
+      if (!path.startsWith("./")) {
+        path = "./" + path;
+      }
+
+      const u = new URL(path, this.baseURL);
+      const data = await cache.load(u.toString());
+      const contents = new TextDecoder().decode(data);
+      const result = await render(contents);
+
+      if (path.endsWith(".tmpl")) {
+        path = path.substring(0, path.length - 5);
+      }
+      this._assets[path] = new TextEncoder().encode(result);
+    }
+  }
+
+  getAssets(): Assets {
+    return this._assets;
+  }
+}

--- a/src/astyle.ts
+++ b/src/astyle.ts
@@ -1,4 +1,4 @@
-import { default as WASI } from "https://deno.land/std@0.167.0/wasi/snapshot_preview1.ts";
+import { default as WASI } from "https://deno.land/std@0.171.0/wasi/snapshot_preview1.ts";
 import { cache } from "https://deno.land/x/cache@0.2.13/mod.ts";
 import { decode, encode } from "./utf8.ts";
 

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,0 +1,19 @@
+import { cache } from "https://deno.land/x/cache@0.2.13/mod.ts";
+
+export async function load(location: string): Promise<Uint8Array> {
+  if (location.startsWith("file:///")) {
+    return Deno.readFileSync(new URL(location));
+  }
+
+  const file = await cache(location);
+  const data = Deno.readFileSync(file.path);
+  if (data.buffer.byteLength > 0) {
+    return data;
+  }
+
+  const response = await fetch(location);
+  if (!response.ok) {
+    throw new Error(`could not load ${location}`);
+  }
+  return new Uint8Array(await response.arrayBuffer());
+}

--- a/src/commands/describe.ts
+++ b/src/commands/describe.ts
@@ -1,0 +1,40 @@
+import { Command } from "https://deno.land/x/cliffy@v0.25.5/command/mod.ts";
+import { Row, Table } from "https://deno.land/x/cliffy@v0.25.5/table/mod.ts";
+
+import { loadTemplateRegistry } from "../utils.ts";
+import { templateCompletion } from "./utils.ts";
+
+export const templates = new Command()
+  .complete("template", async () => await templateCompletion())
+  .arguments("<template:string>")
+  .description("Describe installed template.")
+  .action(async (_options, template: string) => {
+    const registry = await loadTemplateRegistry();
+    const temp = registry.templates[template];
+    if (!template) {
+      throw new Error(`template ${template} is not installed`);
+    }
+
+    console.log(`Name: ${temp.name} [${temp.url}]`);
+    if (temp.description) {
+      console.log(`Description: ${temp.description}`);
+    }
+
+    const variables = temp.variables || [];
+    if (variables.length > 0) {
+      console.log("\nVariables:");
+      new Table()
+        .header(Row.from(["Name", "Description", "Default"]).border(true))
+        .body(
+          variables.map((
+            t,
+          ) => [t.name, t.description || "", (t.default || "").toString()]),
+        )
+        .render();
+    }
+  });
+
+export const command = new Command()
+  .description("Describe available resources.")
+  .default("help")
+  .command("template", templates);

--- a/src/commands/generate.ts
+++ b/src/commands/generate.ts
@@ -1,16 +1,16 @@
 import { Command } from "https://deno.land/x/cliffy@v0.25.5/command/mod.ts";
-import * as yaml from "https://deno.land/std@0.167.0/encoding/yaml.ts";
-import * as streams from "https://deno.land/std@0.167.0/streams/read_all.ts";
-import * as log from "https://deno.land/std@0.167.0/log/mod.ts";
+import * as yaml from "https://deno.land/std@0.171.0/encoding/yaml.ts";
+import * as streams from "https://deno.land/std@0.171.0/streams/read_all.ts";
+import * as log from "https://deno.land/std@0.171.0/log/mod.ts";
 
 import { Configuration, Output } from "../config.ts";
-import { process, writeOutput } from "../process.ts";
+import { processConfiguration, writeOutput } from "../process.ts";
 
 export const command = new Command()
   .arguments("[...configuration:string[]]")
   .description("Run apex generators from a given configuration.")
   .action(async (_options: unknown, configFiles: string[]) => {
-    configFiles = configFiles || [];
+    configFiles ||= [];
     if (!configFiles.length) {
       configFiles = ["apex.yaml"];
     }
@@ -45,9 +45,11 @@ export async function fromConfig(configContents: string) {
 
   const outputs: Output[] = [];
   for (const config of configs) {
-    const o = await process(config);
+    const o = await processConfiguration(config);
     outputs.push(...o);
   }
 
-  outputs.forEach(async (generated) => await writeOutput(generated));
+  for (const generated of outputs) {
+    await writeOutput(generated);
+  }
 }

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,7 +1,10 @@
 import { Command } from "https://deno.land/x/cliffy@v0.25.5/command/mod.ts";
 
 import { Variables } from "../config.ts";
-import { initializeProject } from "../init.ts";
+import {
+  initializeProjectFromGithub,
+  initializeProjectFromTemplate,
+} from "../init.ts";
 import { templateCompletion, varOptions } from "./utils.ts";
 
 export const command = new Command()
@@ -18,17 +21,35 @@ export const command = new Command()
     "checkout branch before processing template",
     { default: "main" },
   )
+  .option(
+    "-s, --spec <string>",
+    "apex specification to use for the project",
+  )
   .description("Initialize a project using a template.")
   .action(async (options, template: string) => {
     const vars = (options || {}).var || ({} as Variables);
-    await initializeProject(
-      ".",
-      template,
-      vars || {},
-      {
-        isNew: false,
-        path: options.path,
-        branch: options.branch,
-      },
-    );
+    if (
+      template.startsWith("https://github.com") &&
+      !template.endsWith(".ts")
+    ) {
+      await initializeProjectFromGithub(
+        ".",
+        template,
+        vars || {},
+        {
+          isNew: false,
+          path: options.path,
+          branch: options.branch,
+          spec: options.spec,
+        },
+      );
+    } else {
+      await initializeProjectFromTemplate(
+        false,
+        ".",
+        template,
+        options.spec,
+        vars || {},
+      );
+    }
   });

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -1,0 +1,40 @@
+import * as path from "https://deno.land/std@0.171.0/path/mod.ts";
+import * as yaml from "https://deno.land/std@0.171.0/encoding/yaml.ts";
+
+import { Command } from "https://deno.land/x/cliffy@v0.25.5/command/mod.ts";
+import { getInstallDirectories } from "../utils.ts";
+import { installTemplate } from "../install.ts";
+import { TemplateMap, TemplateRegistry } from "../config.ts";
+
+export const command = new Command()
+  .arguments("<location:string>")
+  .description("Install templates locally.")
+  .action(async (_options, location: string) => {
+    const updates: TemplateMap = {};
+    await installTemplate(updates, location);
+
+    if (Object.keys(updates).length == 0) {
+      return;
+    }
+
+    let allTemplates: TemplateRegistry = {
+      templates: {},
+    };
+    const dirs = await getInstallDirectories();
+    const templateRegistry = path.join(dirs.home, "templates.yaml");
+    try {
+      const templateListYAML = Deno.readTextFileSync(templateRegistry);
+      allTemplates = yaml.parse(templateListYAML) as TemplateRegistry;
+    } catch (_e) {
+      // Ignore
+    }
+
+    for (const name of Object.keys(updates)) {
+      allTemplates.templates[name] = updates[name];
+    }
+
+    const toSave = yaml.stringify(
+      allTemplates as unknown as Record<string, unknown>,
+    );
+    Deno.writeTextFileSync(templateRegistry, toSave);
+  });

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -1,7 +1,10 @@
 import { Command } from "https://deno.land/x/cliffy@v0.25.5/command/mod.ts";
 
 import { Variables } from "../config.ts";
-import { initializeProject } from "../init.ts";
+import {
+  initializeProjectFromGithub,
+  initializeProjectFromTemplate,
+} from "../init.ts";
 import { templateCompletion, varOptions } from "./utils.ts";
 
 export const command = new Command()
@@ -18,18 +21,35 @@ export const command = new Command()
     "checkout branch before processing template",
     { default: "main" },
   )
+  .option(
+    "-s, --spec <string>",
+    "apex specification to use for the project",
+  )
   .description("Create a new project directory using a template.")
   .action(async (options, template: string, dir: string) => {
     const vars = (options || {}).var || ({} as Variables);
-
-    await initializeProject(
-      dir,
-      template,
-      vars || {},
-      {
-        isNew: true,
-        path: options.path,
-        branch: options.branch,
-      },
-    );
+    if (
+      template.startsWith("https://github.com") &&
+      !template.endsWith(".ts")
+    ) {
+      await initializeProjectFromGithub(
+        dir,
+        template,
+        vars || {},
+        {
+          isNew: true,
+          path: options.path,
+          branch: options.branch,
+          spec: options.spec,
+        },
+      );
+    } else {
+      await initializeProjectFromTemplate(
+        true,
+        dir,
+        template,
+        options.spec,
+        vars || {},
+      );
+    }
   });

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -1,0 +1,141 @@
+import { Command } from "https://deno.land/x/cliffy@v0.25.5/command/mod.ts";
+import * as yaml from "https://deno.land/std@0.171.0/encoding/yaml.ts";
+import * as log from "https://deno.land/std@0.171.0/log/mod.ts";
+import { fromFiles } from "./generate.ts";
+
+import { build$, CommandBuilder } from "https://deno.land/x/dax@0.24.1/mod.ts";
+import { Configuration } from "../config.ts";
+import { processPlugins } from "../process.ts";
+
+interface Task {
+  dependsOn: string[];
+  commands: string[];
+}
+
+export const command = new Command()
+  .arguments("[...tasks:string[]]")
+  .option(
+    "-c, --config <string>",
+    "specify an Apex configuration",
+    { default: "apex.yaml" },
+  )
+  .description("Run tasks.")
+  .action(async (options, tasks: string[]) => {
+    const configFile = options.config || "apex.yaml";
+    const taskMap = await loadTasks(configFile);
+    await runTasks(configFile, taskMap, tasks);
+  });
+
+export async function loadTasks(
+  configFile: string,
+): Promise<Record<string, Task>> {
+  let configContents = "";
+  try {
+    configContents = await Deno.readTextFile(configFile);
+  } catch (_e) {
+    log.error(`Could not read config ${configFile}`);
+    return {};
+  }
+
+  let tasksConfig = yaml.parse(configContents) as Configuration;
+  tasksConfig = await processPlugins(tasksConfig);
+
+  tasksConfig.tasks ||= {};
+  const taskMap: Record<string, Task> = {};
+  let firstTask: string | undefined;
+
+  for (const key of Object.keys(tasksConfig.tasks)) {
+    const commands = tasksConfig.tasks[key] || [];
+    let dependsOn: string[] = [];
+    let taskName = key;
+    const idx = taskName.indexOf(">");
+    if (idx != -1) {
+      const d = taskName.substring(idx + 1).trim();
+      taskName = taskName.substring(0, idx).trim();
+      if (d.length > 0) {
+        dependsOn = d.split(" ").map((v) => v.trim());
+      }
+    }
+
+    if (firstTask == undefined) {
+      firstTask = taskName;
+    }
+
+    taskMap[taskName] = {
+      dependsOn,
+      commands,
+    };
+  }
+
+  return taskMap;
+}
+
+export async function runTasks(
+  configFile: string,
+  taskMap: Record<string, Task>,
+  tasks: string[],
+) {
+  tasks ||= [];
+  if (!tasks.length) {
+    for (const first of Object.keys(taskMap)) {
+      tasks = [first];
+      break;
+    }
+  }
+  if (!tasks.length) {
+    log.error(`no tasks defined`);
+    return;
+  }
+
+  const hasRun = new Set<string>();
+
+  for (const t of tasks) {
+    await run(configFile, hasRun, taskMap, t);
+  }
+}
+
+async function run(
+  configFile: string,
+  hasRun: Set<string>,
+  taskMap: Record<string, Task>,
+  task: string,
+): Promise<void> {
+  if (hasRun.has(task)) {
+    return Promise.resolve();
+  }
+
+  hasRun.add(task);
+
+  const t = taskMap[task];
+  if (!t) {
+    if (task == "generate") {
+      console.log("%capex generate", "font-weight: bold");
+      await fromFiles(configFile);
+      return;
+    }
+
+    throw new Error(`task not defined: "${task}"`);
+  }
+
+  for (const d of t.dependsOn) {
+    await run(configFile, hasRun, taskMap, d);
+  }
+
+  const commandBuilder = new CommandBuilder().noThrow();
+  const $ = build$({ commandBuilder });
+
+  for (let c of t.commands) {
+    c = c.trim();
+    console.log(`%c${c}`, "font-weight: bold");
+
+    const joined = c
+      .split("\n")
+      .map((v) => v.trim())
+      .join(" ");
+
+    const result = await $.raw`${joined}`;
+    if (result.code != 0) {
+      throw new Error(`Aborted with exit code: ${result.code}`);
+    }
+  }
+}

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -6,6 +6,7 @@ import { fromFiles } from "./generate.ts";
 import { build$, CommandBuilder } from "https://deno.land/x/dax@0.24.1/mod.ts";
 import { Configuration } from "../config.ts";
 import { processPlugins } from "../process.ts";
+import { findApexConfig } from "../utils.ts";
 
 interface Task {
   dependsOn: string[];
@@ -22,7 +23,12 @@ export const command = new Command()
   .description("Run tasks.")
   .action(async (options, tasks: string[]) => {
     const configFile = options.config || "apex.yaml";
-    const taskMap = await loadTasks(configFile);
+    const configPath = findApexConfig(configFile);
+    if (!configPath) {
+      console.log("could not find configuration");
+      Deno.exit(1);
+    }
+    const taskMap = await loadTasks(configPath);
     await runTasks(configFile, taskMap, tasks);
   });
 

--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -1,9 +1,9 @@
 import { Command } from "https://deno.land/x/cliffy@v0.25.5/command/mod.ts";
-import * as yaml from "https://deno.land/std@0.167.0/encoding/yaml.ts";
-import * as path from "https://deno.land/std@0.167.0/path/mod.ts";
+import * as yaml from "https://deno.land/std@0.171.0/encoding/yaml.ts";
+import * as path from "https://deno.land/std@0.171.0/path/mod.ts";
 
 import { Configuration } from "../config.ts";
-import { process, writeOutput } from "../process.ts";
+import { processConfiguration, writeOutput } from "../process.ts";
 
 export const command = new Command()
   .arguments("[...configuration:string[]]")
@@ -50,7 +50,7 @@ async function watch(configurations: string[]) {
           let confs = specMap[p];
           if (confs) {
             confs.forEach(async (conf) => {
-              const outputs = await process(conf);
+              const outputs = await processConfiguration(conf);
               outputs.forEach((output) => writeOutput(output));
             });
           }
@@ -60,7 +60,7 @@ async function watch(configurations: string[]) {
             watcher.close();
             await reloadConfigurations();
             confs.forEach(async (conf) => {
-              const outputs = await process(conf);
+              const outputs = await processConfiguration(conf);
               outputs.forEach((output) => writeOutput(output));
             });
             return;

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,15 +7,22 @@ export interface Configuration {
   config?: Config;
   plugins?: string[];
   generates?: Record<string, Target>;
+  tasks?: Record<string, string[]>;
 }
 
 export interface Target {
   module: string;
   visitorClass?: string;
   ifNotExists?: boolean;
+  append?: Visitor[];
   executable?: boolean;
   config?: Config;
   runAfter?: Command[];
+}
+
+export interface Visitor {
+  module: string;
+  visitorClass?: string;
 }
 
 export interface Command {
@@ -33,7 +40,7 @@ export interface Output {
 
 export interface JsonOutput {
   path: string;
-  contents: number[];
+  contents: string;
   mode?: number;
   executable: boolean;
   runAfter?: Command[];
@@ -41,9 +48,47 @@ export interface JsonOutput {
 
 /// TEMPLATE FILES
 
+export type TemplateMap = Record<string, InstalledTemplate>;
+
+export interface InstalledTemplate extends TemplateInfo {
+  url: string;
+}
+
+export interface TemplateRegistry {
+  templates: TemplateMap;
+}
+
+export interface ProcessTemplateArgs {
+  module: string;
+  variables: Variables;
+}
+
+export type Assets = Record<string, Uint8Array>;
+
+export interface FSStructure {
+  files?: string[];
+  directories?: string[];
+  templates?: { [engine: string]: string[] };
+}
+
+export interface TemplateConfig {
+  name?: string;
+  description?: string;
+  variables?: Variable[];
+  specLocation?: string;
+}
+
 export interface Template {
   name?: string;
   description?: string;
+  info?: TemplateInfo;
+  templates?: string[];
+  process?(variables: Variables): Promise<FSStructure>;
+}
+
+export interface TemplateInfo {
+  name: string;
+  description: string;
   variables?: Variable[];
   specLocation?: string;
 }
@@ -52,13 +97,11 @@ export interface Variable {
   name: string;
   message?: string;
   description?: string;
-  type?: "input" | "number" | "confirm";
   prompt?: string;
+  type?: "input" | "number" | "confirm";
   default?: string | number | boolean;
-  required: boolean;
-  loop: boolean;
+  required?: boolean;
+  loop?: boolean;
 }
 
-export type Variables = {
-  [name: string]: string | number | boolean | undefined;
-};
+export type Variables = Record<string, string | number | boolean | undefined>;

--- a/src/init.ts
+++ b/src/init.ts
@@ -1,7 +1,7 @@
-import * as path from "https://deno.land/std@0.167.0/path/mod.ts";
-import * as fs from "https://deno.land/std@0.167.0/fs/mod.ts";
-import * as yaml from "https://deno.land/std@0.167.0/encoding/yaml.ts";
-import { fileExtension } from "https://deno.land/x/file_extension@v2.1.0/mod.ts";
+import * as path from "https://deno.land/std@0.171.0/path/mod.ts";
+import * as fs from "https://deno.land/std@0.171.0/fs/mod.ts";
+import * as yaml from "https://deno.land/std@0.171.0/encoding/yaml.ts";
+import * as log from "https://deno.land/std@0.171.0/log/mod.ts";
 import {
   Confirm,
   ConfirmOptions,
@@ -10,13 +10,44 @@ import {
   Number,
   NumberOptions,
 } from "https://deno.land/x/cliffy@v0.25.5/prompt/mod.ts";
-import * as log from "https://deno.land/std@0.167.0/log/mod.ts";
+import * as eta from "https://deno.land/x/eta@v1.12.3/mod.ts";
 
-import { Output, Template, Variable, Variables } from "./config.ts";
+import {
+  Output,
+  TemplateConfig,
+  TemplateRegistry,
+  Variable,
+  Variables,
+} from "./config.ts";
 import { asBytes } from "./utils.ts";
 import { writeOutput } from "./process.ts";
+import {
+  existsSync,
+  getInstallDirectories,
+  makeRelativeUrl,
+  mkdirAll,
+} from "./utils.ts";
+import { getTemplateInfo, processTemplate } from "./process.ts";
+import { AssetsBuilder } from "./asset_builder.ts";
+import { fileExtension } from "https://deno.land/x/file_extension@v2.1.0/mod.ts";
 
-export async function initializeProject(
+const templateEngines: Record<
+  string,
+  (temp: string, vars: Variables) => Promise<string>
+> = {
+  "eta": async (temp: string, variables: Variables) => {
+    const result = eta.renderAsync(temp, variables);
+    if (result) {
+      return await result;
+    }
+    throw new Error("template failed");
+  },
+  "tmpl": (temp: string, variables: Variables) => {
+    return Promise.resolve(renderTemplate(temp, variables));
+  },
+};
+
+export async function initializeProjectFromGithub(
   dest: string,
   template: string,
   variables: Variables = {},
@@ -88,7 +119,7 @@ export async function getTemplateSources(
     (_) => "",
   );
 
-  const templateConfig: Template = yaml.parse(templateFileSrc) || {};
+  const templateConfig: TemplateConfig = yaml.parse(templateFileSrc) || {};
 
   variables = variables || {};
 
@@ -108,7 +139,7 @@ export async function getTemplateSources(
   // Copy files from template directory.
   const iter = fs.walkSync(realTemplateDir, {
     followSymlinks: true,
-    skip: [/\W.(template|gitkeep|git)$/g],
+    skip: [/\W(template.ts|.template|.gitkeep|.git)$/g],
   });
 
   const output: Output[] = [];
@@ -241,4 +272,151 @@ async function promptFor(
     }
   }
   return values;
+}
+
+export async function initializeProjectFromTemplate(
+  isNew: boolean,
+  dir: string,
+  template: string,
+  spec?: string,
+  variables: Variables = {},
+): Promise<void> {
+  if (
+    !(template.startsWith(".") || template.startsWith("http://") ||
+      template.startsWith("https://"))
+  ) {
+    const dirs = await getInstallDirectories();
+    const templateRegistry = path.join(dirs.home, "templates.yaml");
+    const templateListYAML = Deno.readTextFileSync(templateRegistry);
+    const allTemplates = yaml.parse(templateListYAML) as TemplateRegistry;
+    const resolved = allTemplates.templates[template];
+    if (!resolved) {
+      throw new Error(`template ${template} is not installed`);
+    }
+    template = resolved.url;
+  }
+
+  const url = makeRelativeUrl(template);
+
+  const templateModule = await getTemplateInfo(url.toString());
+  if (!templateModule.info) {
+    throw new Error("template module does not contain info");
+  }
+
+  if (isNew) {
+    mkdirAll(dir, 0o755);
+  }
+
+  variables = variables || {};
+
+  const templateConfig = templateModule.info;
+  templateConfig.variables = templateConfig.variables || [];
+
+  // Parse variable types and filter for unresolved variables.
+  const unresolved = templateConfig.variables.filter((variable) => {
+    if (variables[variable.name]) {
+      if (variable.default) {
+        const type = variable.type || "input";
+        switch (type) {
+          case "number":
+            variables[variable.name] = parseFloat(variable.default as string);
+            break;
+          case "confirm":
+            variables[variable.name] =
+              (variable.default as string).toLowerCase() == "true";
+            break;
+        }
+      }
+      return false;
+    }
+    return true;
+  });
+
+  // Prompt for unresolved variables from the template.
+  for (const variable of unresolved) {
+    variable.message = variable.prompt || variable.description ||
+      `Enter ${variable.name}`;
+    const type = variable.type || "input";
+    switch (type) {
+      case "input":
+        variables[variable.name] = await Input.prompt(
+          variable as unknown as InputOptions,
+        );
+        break;
+      case "number":
+        variables[variable.name] = await Number.prompt(
+          variable as unknown as NumberOptions,
+        );
+        break;
+      case "confirm":
+        variables[variable.name] = await Confirm.prompt(
+          variable as unknown as ConfirmOptions,
+        );
+        break;
+      default:
+        throw new Error(`Unexpected variable type ${type}`);
+    }
+  }
+
+  // Default to name variable to directory name.
+  variables.name = variables.name || path.basename(path.resolve(dir));
+
+  const fsstructure = await processTemplate(template, variables);
+
+  const builder = new AssetsBuilder(url);
+
+  const files = fsstructure.files || [];
+  for (const file of files) {
+    await builder.addFiles(file);
+  }
+
+  // currently, only eta templates are supported.
+  const engineTemplates = fsstructure.templates || {};
+  for (const engine of Object.keys(engineTemplates)) {
+    const engineFn = templateEngines[engine];
+    if (!engine) {
+      throw new Error(`unknown template engine ${engine}`);
+    }
+    const etaTemplates = engineTemplates[engine] || [];
+    for (const file of etaTemplates) {
+      await builder.addTemplates(
+        async (temp: string) => await engineFn(temp, variables),
+        file,
+      );
+    }
+  }
+
+  const assets = builder.getAssets();
+
+  (fsstructure.directories || []).forEach((newDir) => {
+    if (newDir.indexOf("..") != -1) {
+      throw new Error("invalid directory");
+    }
+
+    mkdirAll(path.join(dir, newDir), 0o755);
+  });
+
+  for (const file of Object.keys(assets)) {
+    const target = path.join(dir, file);
+    const dirName = path.dirname(target);
+    mkdirAll(dirName, 0o755);
+
+    if (!isNew && existsSync(target)) {
+      log.info(`${target} already exists. Skipping...`);
+      continue;
+    }
+
+    log.info(`Writing ${target}...`);
+    Deno.writeFileSync(target, assets[file]);
+  }
+
+  // If an existing spec was specified, copy it to the spec location.
+  if (spec) {
+    Deno.copyFile(
+      spec,
+      path.join(dir, templateConfig.specLocation || "apex.axdl"),
+    );
+  }
+
+  // TODO: Run npm install if needed
 }

--- a/src/install.ts
+++ b/src/install.ts
@@ -1,0 +1,71 @@
+import * as log from "https://deno.land/std@0.171.0/log/mod.ts";
+
+import { getTemplateInfo, processTemplate } from "./process.ts";
+import { makeRelativeUrl } from "./utils.ts";
+import * as cache from "./cache.ts";
+import { FSStructure, TemplateMap } from "./config.ts";
+
+export async function installTemplate(
+  registry: TemplateMap,
+  location: string,
+) {
+  const url = makeRelativeUrl(location);
+
+  const module = await getTemplateInfo(url.toString());
+  if (module.info) {
+    log.info(`Installing ${module.info.name}...`);
+    registry[module.info.name] = {
+      ...module.info,
+      url: url.toString(),
+    };
+
+    // Cache possible files
+    let structure: FSStructure | undefined;
+    try {
+      structure = await processTemplate(url.toString(), {
+        "cache": true,
+      });
+    } catch (_err) {
+      // Ignore
+    }
+
+    if (structure) {
+      const files = structure.files || [];
+      for (let path of files) {
+        if (path.indexOf("..") != -1) {
+          throw new Error(`invalid path ${path}`);
+        }
+        if (!path.startsWith("./")) {
+          path = "./" + path;
+        }
+        await cache.load(new URL(path, url).toString());
+      }
+
+      const templates = structure.templates || {};
+      for (const engine of Object.keys(templates)) {
+        const files = templates[engine] || [];
+        for (let path of files) {
+          if (path.indexOf("..") != -1) {
+            throw new Error(`invalid path ${path}`);
+          }
+          if (!path.startsWith("./")) {
+            path = "./" + path;
+          }
+          await cache.load(new URL(path, url).toString());
+        }
+      }
+    }
+  }
+
+  const templates = module.templates || [];
+  for (let template of templates) {
+    if (template.indexOf("..") != -1) {
+      throw new Error(`invalid template path ${template}`);
+    }
+    if (!template.startsWith("./")) {
+      template = "./" + template;
+    }
+    const nestedURL = new URL(template, url);
+    await installTemplate(registry, nestedURL.toString());
+  }
+}

--- a/src/process.ts
+++ b/src/process.ts
@@ -1,8 +1,19 @@
-import * as log from "https://deno.land/std@0.167.0/log/mod.ts";
-import * as path from "https://deno.land/std@0.167.0/path/mod.ts";
+// deno-lint-ignore-file no-explicit-any
+import * as log from "https://deno.land/std@0.171.0/log/mod.ts";
+import * as path from "https://deno.land/std@0.171.0/path/mod.ts";
 import { fileExtension } from "https://deno.land/x/file_extension@v2.1.0/mod.ts";
+import * as base64 from "https://deno.land/std@0.171.0/encoding/base64.ts";
 
-import { Configuration, JsonOutput, Output } from "./config.ts";
+import {
+  Configuration,
+  FSStructure,
+  JsonOutput,
+  Output,
+  ProcessTemplateArgs,
+  Template,
+  TemplateConfig,
+  Variables,
+} from "./config.ts";
 import { cliFormatters, sourceFormatters } from "./formatters.ts";
 import { asBytes, asString } from "./utils.ts";
 
@@ -43,12 +54,32 @@ export async function process(config: Configuration): Promise<Output[]> {
   const output = new TextDecoder().decode(rawOutput);
   log.debug(`Generator output: ${output}`);
   const fromJson = JSON.parse(output) as JsonOutput[];
-  // deno-lint-ignore no-explicit-any
-  const parsedOutput = fromJson.map((o: any) => {
-    o.contents = Uint8Array.from(o.contents);
+  return fromJson.map((o: any) => {
+    o.contents = base64.decode(o.contents);
     return o as Output;
   });
-  return parsedOutput;
+}
+
+export async function processPlugins(
+  config: Configuration,
+): Promise<Configuration> {
+  return await processGeneric<Configuration, Configuration>(
+    "./run_plugins.ts",
+    config,
+  );
+}
+
+export async function processConfiguration(
+  config: Configuration,
+): Promise<Output[]> {
+  const fromJson = await processGeneric<Configuration, JsonOutput[]>(
+    "./run_config.ts",
+    config,
+  );
+  return fromJson.map((o: any) => {
+    o.contents = base64.decode(o.contents);
+    return o as Output;
+  });
 }
 
 export async function writeOutput(generated: Output): Promise<void> {
@@ -88,7 +119,7 @@ export async function writeOutput(generated: Output): Promise<void> {
         .join(" ");
       const args = joined.split(/\s+/);
       const cmd = args.shift()!;
-      log.info(`Running ${joined}`);
+      console.log(`%c${joined}`, "font-weight: bold");
       const command = new Deno.Command(cmd, {
         args: args,
         cwd: cmdConfig.dir,
@@ -97,4 +128,68 @@ export async function writeOutput(generated: Output): Promise<void> {
       await child.status;
     });
   }
+}
+
+export async function getTemplateInfo(
+  module: string,
+): Promise<Template> {
+  return await processGeneric<string, TemplateConfig>(
+    "./run_template_info.ts",
+    module,
+  );
+}
+
+export async function processTemplate(
+  module: string,
+  variables: Variables,
+): Promise<FSStructure> {
+  return await processGeneric<ProcessTemplateArgs, FSStructure>(
+    "./run_process_template.ts",
+    {
+      module,
+      variables,
+    },
+  );
+}
+
+async function processGeneric<I, O>(
+  url: string,
+  config: I,
+): Promise<O> {
+  log.debug(`Input is: ${JSON.stringify(config, null, 2)}`);
+
+  // Run the generation process with restricted permissions.
+  const href = new URL(url, import.meta.url).href;
+  const p = await Deno.run({
+    cmd: [
+      Deno.execPath(),
+      "run",
+      "--allow-read",
+      "--allow-net=deno.land,raw.githubusercontent.com",
+      href,
+    ],
+    stdout: "piped",
+    stderr: "piped",
+    stdin: "piped",
+  });
+
+  const input = JSON.stringify(config);
+  await p.stdin.write(new TextEncoder().encode(input));
+  p.stdin.close();
+
+  // Reading the outputs and closes their pipes
+  const rawOutput = await p.output();
+  const rawError = await p.stderrOutput();
+
+  const { code } = await p.status();
+  p.close();
+
+  if (code !== 0) {
+    const errorString = new TextDecoder().decode(rawError);
+    throw new Error(errorString);
+  }
+
+  const output = new TextDecoder().decode(rawOutput);
+  log.debug(`Generator output: ${output}`);
+  return JSON.parse(output) as O;
 }

--- a/src/process.ts
+++ b/src/process.ts
@@ -46,9 +46,14 @@ export async function process(config: Configuration): Promise<Output[]> {
   const { code } = await p.status();
   p.close();
 
+  const errorString = new TextDecoder().decode(rawError);
+
   if (code !== 0) {
-    const errorString = new TextDecoder().decode(rawError);
     throw new Error(errorString);
+  }
+
+  if (errorString && errorString.length > 0) {
+    console.log(errorString);
   }
 
   const output = new TextDecoder().decode(rawOutput);
@@ -184,9 +189,14 @@ async function processGeneric<I, O>(
   const { code } = await p.status();
   p.close();
 
+  const errorString = new TextDecoder().decode(rawError);
+
   if (code !== 0) {
-    const errorString = new TextDecoder().decode(rawError);
     throw new Error(errorString);
+  }
+
+  if (errorString && errorString.length > 0) {
+    console.log(errorString);
   }
 
   const output = new TextDecoder().decode(rawOutput);

--- a/src/run_config.ts
+++ b/src/run_config.ts
@@ -1,0 +1,21 @@
+import * as streams from "https://deno.land/std@0.171.0/streams/read_all.ts";
+import * as base64 from "https://deno.land/std@0.171.0/encoding/base64.ts";
+
+import { Configuration } from "./config.ts";
+import { processConfig } from "./generate.ts";
+
+// Detect piped input
+if (!Deno.isatty(Deno.stdin.rid) && import.meta.main) {
+  const stdinContent = await streams.readAll(Deno.stdin);
+  const content = new TextDecoder().decode(stdinContent);
+  try {
+    const config = JSON.parse(content) as Configuration;
+    console.log(JSON.stringify(
+      await processConfig(config),
+      (_, v) => v instanceof Uint8Array ? base64.encode(v) : v,
+    ));
+  } catch (e) {
+    console.error(e);
+    throw e;
+  }
+}

--- a/src/run_plugins.ts
+++ b/src/run_plugins.ts
@@ -1,0 +1,21 @@
+import * as streams from "https://deno.land/std@0.171.0/streams/read_all.ts";
+import * as base64 from "https://deno.land/std@0.171.0/encoding/base64.ts";
+
+import { Configuration } from "./config.ts";
+import { processPlugins } from "./generate.ts";
+
+// Detect piped input
+if (!Deno.isatty(Deno.stdin.rid) && import.meta.main) {
+  const stdinContent = await streams.readAll(Deno.stdin);
+  const content = new TextDecoder().decode(stdinContent);
+  try {
+    const config = JSON.parse(content) as Configuration;
+    console.log(JSON.stringify(
+      await processPlugins(config),
+      (_, v) => v instanceof Uint8Array ? base64.encode(v) : v,
+    ));
+  } catch (e) {
+    console.error(e);
+    throw e;
+  }
+}

--- a/src/run_process_template.ts
+++ b/src/run_process_template.ts
@@ -1,0 +1,22 @@
+import * as streams from "https://deno.land/std@0.171.0/streams/read_all.ts";
+
+import { ProcessTemplateArgs } from "./config.ts";
+import { importTemplate } from "./generate.ts";
+
+// Detect piped input
+if (!Deno.isatty(Deno.stdin.rid) && import.meta.main) {
+  const stdinContent = await streams.readAll(Deno.stdin);
+  const content = new TextDecoder().decode(stdinContent);
+  try {
+    const args = JSON.parse(content) as ProcessTemplateArgs;
+    const temp = await importTemplate(args.module);
+    if (!temp.process) {
+      throw new Error("template does not implement process");
+    }
+    const fsstruct = await temp.process(args.variables);
+    console.log(JSON.stringify(fsstruct));
+  } catch (e) {
+    console.error(e);
+    throw e;
+  }
+}

--- a/src/run_template_info.ts
+++ b/src/run_template_info.ts
@@ -1,0 +1,16 @@
+import * as streams from "https://deno.land/std@0.171.0/streams/read_all.ts";
+
+import { importTemplate } from "./generate.ts";
+
+// Detect piped input
+if (!Deno.isatty(Deno.stdin.rid) && import.meta.main) {
+  const stdinContent = await streams.readAll(Deno.stdin);
+  const content = new TextDecoder().decode(stdinContent);
+  try {
+    const module = JSON.parse(content) as string;
+    console.log(JSON.stringify(await importTemplate(module)));
+  } catch (e) {
+    console.error(e);
+    throw e;
+  }
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -106,3 +106,28 @@ export async function setupLogger(level: log.LevelName) {
     },
   });
 }
+
+export function findApexConfig(config = "apex.yaml"): string | undefined {
+  try {
+    let dir = Deno.cwd();
+    let p = path.join(dir, config);
+    if (existsSync(p)) {
+      Deno.chdir(path.dirname(p));
+      return p;
+    }
+    while (true) {
+      const prev = dir;
+      dir = path.resolve(dir, "../");
+      if (prev == dir) {
+        return undefined;
+      }
+      p = path.join(dir, config);
+      if (existsSync(p)) {
+        Deno.chdir(dir);
+        return p;
+      }
+    }
+  } catch (_e) {
+    return undefined;
+  }
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,10 +1,9 @@
-import * as path from "https://deno.land/std@0.167.0/path/mod.ts";
+import * as path from "https://deno.land/std@0.171.0/path/mod.ts";
 import home_dir from "https://deno.land/x/dir@1.5.1/home_dir/mod.ts";
-import * as yaml from "https://deno.land/std@0.167.0/encoding/yaml.ts";
-import { walkSync } from "https://deno.land/std@0.167.0/fs/mod.ts";
-import * as log from "https://deno.land/std@0.167.0/log/mod.ts";
+import * as yaml from "https://deno.land/std@0.171.0/encoding/yaml.ts";
+import * as log from "https://deno.land/std@0.171.0/log/mod.ts";
 
-import { Template } from "./config.ts";
+import { InstalledTemplate, TemplateRegistry } from "./config.ts";
 
 // This function is copied here because it is deprecated for a reason
 // that does not match ou use case.
@@ -20,38 +19,30 @@ export function existsSync(filePath: string | URL): boolean {
   }
 }
 
-export async function templateList(): Promise<Template[]> {
+export async function loadTemplateRegistry(): Promise<TemplateRegistry> {
   const dirs = await getInstallDirectories();
-  // Copy files from template directory.
-  const iter = walkSync(dirs.templates, {
-    followSymlinks: true,
-    match: [/\W.template$/g],
-  });
-
-  const templates: Template[] = [];
-  for (const f of iter) {
-    const name = path
-      .relative(dirs.templates, path.dirname(f.path))
-      .replace("\\", "/");
-    const templateData = Deno.readTextFileSync(f.path);
-    const templateConfig = yaml.parse(templateData) as Template;
-    templates.push({
-      ...templateConfig,
-      name,
-    });
+  const templateRegistry = path.join(dirs.home, "templates.yaml");
+  try {
+    const templateListYAML = Deno.readTextFileSync(templateRegistry);
+    return yaml.parse(templateListYAML) as TemplateRegistry;
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) {
+      return {
+        templates: {},
+      } as TemplateRegistry;
+    }
+    throw error;
   }
+}
 
-  return templates.sort((a, b) =>
-    new String(a.name).localeCompare(
-      b.name ||
-        "",
-    )
-  );
+export async function templateList(): Promise<InstalledTemplate[]> {
+  const allTemplates = await loadTemplateRegistry();
+  const templates = Object.values(allTemplates.templates);
+  return templates.sort((a, b) => new String(a.name).localeCompare(b.name));
 }
 
 export interface ApexDirs {
   home: string;
-  templates: string;
   definitions: string;
 }
 
@@ -62,18 +53,13 @@ export async function getInstallDirectories(): Promise<ApexDirs> {
   }
 
   const apexHome = path.join(homeDirectory, ".apex");
-  const templatesHome = path.join(apexHome, "templates");
   const definitionsHome = path.join(apexHome, "definitions");
 
   await mkdirAll(apexHome, 0o700);
-  await Promise.all([
-    mkdirAll(templatesHome, 0o700),
-    mkdirAll(definitionsHome, 0o700),
-  ]);
+  await mkdirAll(definitionsHome, 0o700);
 
   return {
     home: apexHome,
-    templates: templatesHome,
     definitions: definitionsHome,
   };
 }

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,6 +1,6 @@
-import { assertEquals } from "https://deno.land/std@0.167.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.171.0/testing/asserts.ts";
 import { process } from "../src/process.ts";
-import * as path from "https://deno.land/std@0.167.0/path/mod.ts";
+import * as path from "https://deno.land/std@0.171.0/path/mod.ts";
 import { asBytes } from "../src/utils.ts";
 
 const __dirname = new URL(".", import.meta.url).pathname;

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -14,7 +14,8 @@ Deno.test(
       generates: {
         "file.rs": {
           module:
-            "https://raw.githubusercontent.com/apexlang/codegen/deno-wip/src/rust/rust-basic.ts",
+            "https://raw.githubusercontent.com/apexlang/codegen/main/src/rust/rust-basic.ts",
+          visitorClass: "RustBasic",
         },
       },
     });

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -1,6 +1,6 @@
-import { assertEquals } from "https://deno.land/std@0.167.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.171.0/testing/asserts.ts";
 import { getTemplateSources, getUnresolved } from "../src/init.ts";
-import * as path from "https://deno.land/std@0.167.0/path/mod.ts";
+import * as path from "https://deno.land/std@0.171.0/path/mod.ts";
 import { asBytes, setupLogger } from "../src/utils.ts";
 import { Variable } from "../src/config.ts";
 

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -1,7 +1,7 @@
-import * as apex from "https://deno.land/x/apex_core@v0.1.1/mod.ts";
-import { assertEquals } from "https://deno.land/std@0.167.0/testing/asserts.ts";
+import * as apex from "https://deno.land/x/apex_core@v0.1.2/mod.ts";
+import { assertEquals } from "https://deno.land/std@0.171.0/testing/asserts.ts";
 import { processConfig, processPlugin } from "../src/generate.ts";
-import * as path from "https://deno.land/std@0.167.0/path/mod.ts";
+import * as path from "https://deno.land/std@0.171.0/path/mod.ts";
 import { asBytes, setupLogger } from "../src/utils.ts";
 
 const __dirname = new URL(".", import.meta.url).pathname;

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -40,6 +40,10 @@ Deno.test(
       "Test.0.file": { module: generator },
       "Test.1.file": { module: generator },
     });
+
+    assertEquals(config.tasks, {
+      "start": [`echo "test"`],
+    });
   },
 );
 

--- a/test/template.test.ts
+++ b/test/template.test.ts
@@ -1,0 +1,23 @@
+import { assertEquals } from "https://deno.land/std@0.171.0/testing/asserts.ts";
+import { processTemplate } from "../src/process.ts";
+import * as path from "https://deno.land/std@0.171.0/path/mod.ts";
+
+const __dirname = new URL(".", import.meta.url).pathname;
+
+Deno.test(
+  "template",
+  { permissions: { read: true, net: true, run: true } },
+  async () => {
+    const generated = await processTemplate(
+      path.join(__dirname, "template", "template.ts"),
+      {},
+    );
+
+    assertEquals(generated, {
+      files: ["file.js"],
+      templates: {
+        "tmpl": ["file.txt.tmpl"],
+      },
+    });
+  },
+);

--- a/test/template/template.ts
+++ b/test/template/template.ts
@@ -1,0 +1,31 @@
+// deno-lint-ignore-file require-await
+import { FSStructure, Template } from "../../src/config.ts";
+
+const template: Template = {
+  info: {
+    name: "@apex/test",
+    description: "My test template",
+    variables: [
+      {
+        name: "test",
+        description: "test",
+        type: "input",
+        prompt: "Enter test",
+        default: "test1234",
+      },
+    ],
+  },
+
+  async process(_vars): Promise<FSStructure> {
+    return {
+      files: ["file.js"],
+      templates: {
+        "tmpl": [
+          "file.txt.tmpl",
+        ],
+      },
+    };
+  },
+};
+
+export default template;

--- a/test/test-generator.ts
+++ b/test/test-generator.ts
@@ -1,4 +1,4 @@
-import * as model from "https://deno.land/x/apex_core@v0.1.0/model/mod.ts";
+import * as model from "https://deno.land/x/apex_core@v0.1.2/model/mod.ts";
 
 type Context = model.Context;
 

--- a/test/test-plugin.ts
+++ b/test/test-plugin.ts
@@ -19,5 +19,9 @@ export default function (
       module: generator,
     };
   }
+
+  config.tasks ||= {};
+  config.tasks["start"] = [`echo "test"`];
+
   return config;
 }

--- a/test/test-plugin.ts
+++ b/test/test-plugin.ts
@@ -1,6 +1,6 @@
 import { Configuration } from "../src/config.ts";
-import * as apex from "https://deno.land/x/apex_core@v0.1.0/mod.ts";
-import * as path from "https://deno.land/std@0.167.0/path/mod.ts";
+import * as apex from "https://deno.land/x/apex_core@v0.1.2/mod.ts";
+import * as path from "https://deno.land/std@0.171.0/path/mod.ts";
 
 const __dirname = new URL(".", import.meta.url).pathname;
 const generator = path.join(__dirname, "test-generator.ts");


### PR DESCRIPTION
This PR adds:

* Installing and processing templates from Deno-friendly URLs
* Adding running task targets defined in the config
* Ability to append the output of multiple visitors into a single generated file
* Rendering imports after visitor(s) have run