### PR TITLE
Misc fixes

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -66,6 +66,7 @@ export interface ProcessTemplateArgs {
 export type Assets = Record<string, Uint8Array>;
 
 export interface FSStructure {
+  variables?: Record<string, string | number | boolean>;
   files?: string[];
   directories?: string[];
   templates?: { [engine: string]: string[] };

--- a/src/init.ts
+++ b/src/init.ts
@@ -363,6 +363,13 @@ export async function initializeProjectFromTemplate(
 
   const fsstructure = await processTemplate(template, variables);
 
+  // Add dynamic variables
+  if (fsstructure.variables) {
+    for (const key of Object.keys(fsstructure.variables)) {
+      variables[key] = fsstructure.variables[key];
+    }
+  }
+
   const builder = new AssetsBuilder(url);
 
   const files = fsstructure.files || [];

--- a/src/init.ts
+++ b/src/init.ts
@@ -399,7 +399,7 @@ export async function initializeProjectFromTemplate(
   for (const file of Object.keys(assets)) {
     const target = path.join(dir, file);
     const dirName = path.dirname(target);
-    mkdirAll(dirName, 0o755);
+    await mkdirAll(dirName, 0o755);
 
     if (!isNew && existsSync(target)) {
       log.info(`${target} already exists. Skipping...`);

--- a/src/install.ts
+++ b/src/install.ts
@@ -13,12 +13,6 @@ export async function installTemplate(
 
   const module = await getTemplateInfo(url.toString());
   if (module.info) {
-    log.info(`Installing ${module.info.name}...`);
-    registry[module.info.name] = {
-      ...module.info,
-      url: url.toString(),
-    };
-
     // Cache possible files
     let structure: FSStructure | undefined;
     try {
@@ -30,6 +24,12 @@ export async function installTemplate(
     }
 
     if (structure) {
+      log.info(`Installing ${module.info.name}...`);
+      registry[module.info.name] = {
+        ...module.info,
+        url: url.toString(),
+      };
+
       const files = structure.files || [];
       for (let path of files) {
         if (path.indexOf("..") != -1) {


### PR DESCRIPTION
This PR fixes:

* `await` for mkdirAll
* Only install templates with FS structure to the registry

and adds the ability for template process methods to add dynamic variables (such as plugin location relative to the template).