### PR TITLE
Added tests for apex run & added config variables to env

### DIFF
--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -1,16 +1,15 @@
 import { Command } from "https://deno.land/x/cliffy@v0.25.5/command/mod.ts";
-import * as yaml from "https://deno.land/std@0.171.0/encoding/yaml.ts";
 import * as log from "https://deno.land/std@0.171.0/log/mod.ts";
-import { fromFiles } from "./generate.ts";
+import { fromConfigs } from "./generate.ts";
 
-import { build$, CommandBuilder } from "https://deno.land/x/dax@0.24.1/mod.ts";
-import { Configuration } from "../config.ts";
+import { Configuration, parseConfigYaml } from "../config.ts";
 import { processPlugins } from "../process.ts";
-import { findApexConfig } from "../utils.ts";
+import { findApexConfig, flatten } from "../utils.ts";
+import { CmdOutput, Task } from "../task.ts";
 
-interface Task {
-  dependsOn: string[];
-  commands: string[];
+export interface RunOptions {
+  config?: string;
+  quiet?: boolean;
 }
 
 export const command = new Command()
@@ -20,46 +19,56 @@ export const command = new Command()
     "specify an Apex configuration",
     { default: "apex.yaml" },
   )
+  .option(
+    "-q, --quiet",
+    "silence extraneous apex output",
+  )
   .description("Run tasks.")
-  .action(async (options, tasks: string[]) => {
+  .action(async (options: RunOptions, tasks: string[]) => {
     const configFile = options.config || "apex.yaml";
     const configPath = findApexConfig(configFile);
     if (!configPath) {
       console.log("could not find configuration");
       Deno.exit(1);
     }
-    const taskMap = await loadTasks(configPath);
-    await runTasks(configFile, taskMap, tasks);
+    let config;
+    try {
+      config = await Deno.readTextFile(configPath);
+    } catch (_e) {
+      log.error(`Could not read config ${configPath}`);
+      return {};
+    }
+    const configs = parseConfigYaml(config);
+    for (const cfg of configs) {
+      const taskMap = await loadTasks(cfg);
+      await runTasks(cfg, taskMap, tasks, options);
+    }
   });
 
-export async function loadTasks(
-  configFile: string,
-): Promise<Record<string, Task>> {
-  let configContents = "";
-  try {
-    configContents = await Deno.readTextFile(configFile);
-  } catch (_e) {
-    log.error(`Could not read config ${configFile}`);
-    return {};
-  }
-
-  let tasksConfig = yaml.parse(configContents) as Configuration;
-  tasksConfig = await processPlugins(tasksConfig);
-
-  tasksConfig.tasks ||= {};
+export function parseTasks(
+  config: Configuration,
+): Record<string, Task> {
+  config.tasks ||= {};
   const taskMap: Record<string, Task> = {};
   let firstTask: string | undefined;
 
-  for (const key of Object.keys(tasksConfig.tasks)) {
-    const commands = tasksConfig.tasks[key] || [];
-    let dependsOn: string[] = [];
+  for (const key of Object.keys(config.tasks)) {
+    let task;
+    const def = config.tasks[key];
+    if (Array.isArray(def)) {
+      task = new Task({ cmds: def });
+    } else {
+      task = new Task(def);
+    }
+
     let taskName = key;
     const idx = taskName.indexOf(">");
     if (idx != -1) {
       const d = taskName.substring(idx + 1).trim();
       taskName = taskName.substring(0, idx).trim();
       if (d.length > 0) {
-        dependsOn = d.split(" ").map((v) => v.trim());
+        // prepend dependencies written in shorthand to the explicit deps.
+        task.deps.unshift(...d.split(" ").map((v) => v.trim()));
       }
     }
 
@@ -67,27 +76,31 @@ export async function loadTasks(
       firstTask = taskName;
     }
 
-    taskMap[taskName] = {
-      dependsOn,
-      commands,
-    };
+    taskMap[taskName] = task;
   }
 
   return taskMap;
 }
 
+export async function loadTasks(
+  config: Configuration,
+): Promise<Record<string, Task>> {
+  config = await processPlugins(config);
+
+  return parseTasks(config);
+}
+
 export async function runTasks(
-  configFile: string,
+  config: Configuration,
   taskMap: Record<string, Task>,
-  tasks: string[],
-) {
-  tasks ||= [];
-  if (!tasks.length) {
-    for (const first of Object.keys(taskMap)) {
-      tasks = [first];
-      break;
-    }
+  tasks: string[] = [],
+  opts: RunOptions = {},
+): Promise<Record<string, CmdOutput> | undefined> {
+  if (tasks.length === 0) {
+    const defaultTask = Object.keys(taskMap).shift();
+    tasks = defaultTask ? [defaultTask] : [];
   }
+
   if (!tasks.length) {
     log.error(`no tasks defined`);
     return;
@@ -96,18 +109,19 @@ export async function runTasks(
   const hasRun = new Set<string>();
 
   for (const t of tasks) {
-    await run(configFile, hasRun, taskMap, t);
+    await run(config, hasRun, taskMap, t, opts);
   }
 }
 
 async function run(
-  configFile: string,
+  config: Configuration,
   hasRun: Set<string>,
   taskMap: Record<string, Task>,
   task: string,
-): Promise<void> {
+  opts: RunOptions = {},
+): Promise<Record<string, CmdOutput> | undefined> {
   if (hasRun.has(task)) {
-    return Promise.resolve();
+    return Promise.resolve(undefined);
   }
 
   hasRun.add(task);
@@ -116,32 +130,21 @@ async function run(
   if (!t) {
     if (task == "generate") {
       console.log("%capex generate", "font-weight: bold");
-      await fromFiles(configFile);
+      await fromConfigs([config]);
       return;
     }
 
     throw new Error(`task not defined: "${task}"`);
   }
 
-  for (const d of t.dependsOn) {
-    await run(configFile, hasRun, taskMap, d);
+  for (const d of t.deps) {
+    await run(config, hasRun, taskMap, d, opts);
   }
 
-  const commandBuilder = new CommandBuilder().noThrow();
-  const $ = build$({ commandBuilder });
+  const env = {
+    apex_spec: config.spec,
+  };
+  Object.assign(env, flatten("apex_config", config.config));
 
-  for (let c of t.commands) {
-    c = c.trim();
-    console.log(`%c${c}`, "font-weight: bold");
-
-    const joined = c
-      .split("\n")
-      .map((v) => v.trim())
-      .join(" ");
-
-    const result = await $.raw`${joined}`;
-    if (result.code != 0) {
-      throw new Error(`Aborted with exit code: ${result.code}`);
-    }
-  }
+  await t.run({ quiet: opts.quiet, env });
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,6 @@
+import { TaskConfig } from "./task.ts";
+import * as yaml from "https://deno.land/std@0.171.0/encoding/yaml.ts";
+
 export type Config = { [key: string]: unknown };
 
 /// MAIN CONFIG
@@ -7,8 +10,10 @@ export interface Configuration {
   config?: Config;
   plugins?: string[];
   generates?: Record<string, Target>;
-  tasks?: Record<string, string[]>;
+  tasks?: Record<string, TaskDefinition>;
 }
+
+export type TaskDefinition = string[] | TaskConfig;
 
 export interface Target {
   module: string;
@@ -105,3 +110,11 @@ export interface Variable {
 }
 
 export type Variables = Record<string, string | number | boolean | undefined>;
+
+// TODO: need to validate yaml for a TS interface rather than assume it's OK.
+export function parseConfigYaml(contents: string): Configuration[] {
+  return contents
+    .split("---\n")
+    .map((v) => v.trim())
+    .map((v) => yaml.parse(v) as Configuration);
+}

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -16,9 +16,14 @@ import { existsSync, makeRelativeUrl } from "./utils.ts";
 export async function processPlugins(
   config: Configuration,
 ): Promise<Configuration> {
-  const apexSource = await Deno.readTextFile(config.spec);
-  // TODO: implement resolver callback
-  const doc = apex.parse(apexSource);
+  let doc;
+  try {
+    const apexSource = await Deno.readTextFile(config.spec);
+    // TODO: implement resolver callback
+    doc = apex.parse(apexSource);
+  } catch {
+    doc = new apex.ast.Document(undefined, []);
+  }
 
   return await processPlugin(doc, config);
 }

--- a/src/task.ts
+++ b/src/task.ts
@@ -1,0 +1,62 @@
+import { build$, CommandBuilder } from "https://deno.land/x/dax@0.24.1/mod.ts";
+
+export enum TaskRunner {
+  Dax = "dax",
+}
+
+export type TaskConfig = Partial<Pick<Task, keyof Task>>;
+
+export interface CmdOutput {
+  cmd: string;
+  output: Uint8Array;
+}
+
+export class Task {
+  runner = TaskRunner.Dax;
+  deps: string[] = [];
+  cmds: string[] = [];
+
+  constructor(config: TaskConfig = {}) {
+    this.runner = config.runner || TaskRunner.Dax;
+    this.deps = config.deps || [];
+    this.cmds = config.cmds || [];
+  }
+
+  async run(
+    opts: { capture?: boolean; quiet?: boolean; env?: Record<string, string> } =
+      {},
+  ): Promise<Record<string, CmdOutput> | undefined> {
+    const output: Record<string, CmdOutput> = {};
+
+    if (this.runner === TaskRunner.Dax) {
+      const commandBuilder = new CommandBuilder().noThrow();
+      const $ = build$({ commandBuilder });
+      const env = opts.env || {};
+
+      for (let c of this.cmds) {
+        c = c.trim();
+
+        const joined = c
+          .split("\n")
+          .map((v) => v.trim())
+          .join(" ");
+
+        let result;
+        if (opts.capture) {
+          result = await $.raw`${joined}`.env(env).captureCombined();
+          output[joined] = { cmd: c, output: result.combinedBytes };
+        } else {
+          if (!opts.quiet) {
+            console.log(`%c${c}`, "font-weight: bold");
+          }
+          result = await $.raw`${joined}`.env(env);
+        }
+        if (result.code != 0) {
+          throw new Error(`Aborted with exit code: ${result.code}`);
+        }
+      }
+      return output;
+    }
+    throw new Error(`unknown runner ${this.runner}`);
+  }
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -131,3 +131,25 @@ export function findApexConfig(config = "apex.yaml"): string | undefined {
     return undefined;
   }
 }
+
+export function flatten(prefix: string, obj: any): any {
+  if (obj === null || obj === undefined) {
+    return { [prefix]: "" };
+  } else if (typeof obj === "string") {
+    return { [prefix]: obj };
+  } else if (Array.isArray(obj)) {
+    const result: any = {};
+    for (let i = 0; i < obj.length; i++) {
+      Object.assign(result, flatten(`${prefix}_${i}`, obj[i]));
+    }
+    return result;
+  } else if (typeof obj === "object") {
+    const result = {};
+    for (const [key, value] of Object.entries(obj)) {
+      Object.assign(result, flatten(`${prefix}_${key}`, value));
+    }
+    return result;
+  } else {
+    return { [prefix]: obj.toString() };
+  }
+}

--- a/test/fixtures/task-apex-env.yaml
+++ b/test/fixtures/task-apex-env.yaml
@@ -1,0 +1,6 @@
+spec: 'my-spec.yaml'
+config:
+  some_val: 12345
+tasks:
+  test:
+    - echo My spec is $apex_spec and some_val is $apex_config_some_val

--- a/test/fixtures/task-deps.yaml
+++ b/test/fixtures/task-deps.yaml
@@ -1,0 +1,6 @@
+spec: ''
+tasks:
+  test > b:
+    - echo Hello World
+  b:
+    - echo "From b"

--- a/test/fixtures/task-env-vars.yaml
+++ b/test/fixtures/task-env-vars.yaml
@@ -1,0 +1,4 @@
+spec: ''
+tasks:
+  test:
+    - echo Hello $NAME

--- a/test/fixtures/task-explicit.yaml
+++ b/test/fixtures/task-explicit.yaml
@@ -1,0 +1,9 @@
+spec: ''
+tasks:
+  test:
+    cmds:
+      - echo Hello World
+    deps:
+      - b
+  b:
+    - echo "From b"

--- a/test/fixtures/task-hello-world.yaml
+++ b/test/fixtures/task-hello-world.yaml
@@ -1,0 +1,4 @@
+spec: ''
+tasks:
+  test:
+    - echo Hello World

--- a/test/fixtures/task-refs.yaml
+++ b/test/fixtures/task-refs.yaml
@@ -1,0 +1,7 @@
+spec: ''
+tasks:
+  test > b:
+    - echo Hello World
+  c: &c
+    - 'echo From c'
+  b: *c

--- a/test/run.test.ts
+++ b/test/run.test.ts
@@ -1,0 +1,145 @@
+import {
+  assert,
+  assertEquals,
+} from "https://deno.land/std@0.171.0/testing/asserts.ts";
+import { runTasks } from "../src/commands/run.ts";
+import { Task } from "../src/task.ts";
+const __dirname = new URL(".", import.meta.url).pathname;
+
+async function runFixture(
+  config: string,
+  task: string,
+  env: Record<string, string> = {},
+): Promise<Uint8Array> {
+  const proc = Deno.run({
+    env,
+    stderr: "inherit",
+    stdout: "piped",
+    cmd: [
+      "deno",
+      "run",
+      "--allow-all",
+      "--unstable",
+      "./apex.ts",
+      "run",
+      "--config",
+      config,
+      "--quiet",
+      task,
+    ],
+  });
+  const out = await proc.output();
+  await proc.close();
+  return out;
+}
+
+function doTest(def: TestDef) {
+  Deno.test(
+    `apex run -c ${def.fixture} ${def.task}`,
+    { permissions: { read: true, run: true, env: true, net: true } },
+    async () => {
+      const output = await runFixture(def.fixture, def.task, def.env);
+      assertEquals(new TextDecoder().decode(output), def.expected);
+    },
+  );
+}
+
+function strEnc(str: string): Uint8Array {
+  return new TextEncoder().encode(str);
+}
+
+Deno.test(
+  "no tasks defined",
+  async () => {
+    const output = await runTasks({ spec: "" }, {}, []);
+    assert(true, "should not throw");
+  },
+);
+
+Deno.test(
+  "basic echo",
+  { permissions: { read: true, run: true, env: true } },
+  async () => {
+    const output = await new Task({ cmds: ["echo Howdy"] }).run({
+      capture: true,
+    })!;
+    assertEquals(output, {
+      "echo Howdy": {
+        cmd: "echo Howdy",
+        output: new TextEncoder().encode("Howdy\n"),
+      },
+    });
+  },
+);
+
+Deno.test(
+  "shell exec",
+  { permissions: { read: true, run: true, env: true } },
+  async () => {
+    const output = await new Task({ cmds: ["sh -c 'echo Test'"] }).run({
+      capture: true,
+    })!;
+    assertEquals(output, {
+      "sh -c 'echo Test'": {
+        cmd: "sh -c 'echo Test'",
+        output: strEnc("Test\n"),
+      },
+    });
+  },
+);
+
+Deno.test(
+  "not found",
+  { permissions: { read: true, run: true, env: true } },
+  async () => {
+    try {
+      const output = await new Task({ cmds: ["DOES_NOT_EXIST"] }).run()!;
+      assert(false, "should throw");
+    } catch {}
+  },
+);
+
+interface TestDef {
+  fixture: string;
+  task: string;
+  expected: string;
+  env?: Record<string, string>;
+}
+
+const tests: TestDef[] = [
+  {
+    fixture: "test/fixtures/task-hello-world.yaml",
+    task: "test",
+    expected: "Hello World\n",
+  },
+  {
+    fixture: "test/fixtures/task-deps.yaml",
+    task: "test",
+    expected: "From b\nHello World\n",
+  },
+  {
+    fixture: "test/fixtures/task-explicit.yaml",
+    task: "test",
+    expected: "From b\nHello World\n",
+  },
+  {
+    fixture: "test/fixtures/task-refs.yaml",
+    task: "test",
+    expected: "From c\nHello World\n",
+  },
+  {
+    fixture: "test/fixtures/task-env-vars.yaml",
+    task: "test",
+    expected: "Hello World\n",
+    env: {
+      NAME: "World",
+    },
+  },
+  {
+    fixture: "test/fixtures/task-apex-env.yaml",
+    task: "test",
+    expected: "My spec is my-spec.yaml and some_val is 12345\n",
+  },
+];
+
+tests.forEach(doTest);

--- a/test/tasks.test.ts
+++ b/test/tasks.test.ts
@@ -1,0 +1,110 @@
+import { assertEquals } from "https://deno.land/std@0.171.0/testing/asserts.ts";
+import { parseTasks } from "../src/commands/run.ts";
+import { Task, TaskRunner } from "../src/task.ts";
+
+Deno.test(
+  "run task array shorthand",
+  async () => {
+    const tasks = await parseTasks({
+      spec: "",
+      tasks: { start: [`echo "test"`] },
+    });
+
+    assertEquals(tasks, {
+      "start": new Task({
+        cmds: [`echo "test"`],
+        deps: [],
+        runner: TaskRunner.Dax,
+      }),
+    });
+  },
+);
+
+Deno.test(
+  "run a > b shorthand",
+  async () => {
+    const tasks = await parseTasks({
+      spec: "",
+      tasks: { "start > a b c": [`echo "test"`], a: [], b: [], c: [] },
+    });
+
+    assertEquals(tasks, {
+      "start": new Task({
+        cmds: [`echo "test"`],
+        deps: ["a", "b", "c"],
+        runner: TaskRunner.Dax,
+      }),
+      "a": new Task({
+        cmds: [],
+        deps: [],
+        runner: TaskRunner.Dax,
+      }),
+      "b": new Task({
+        cmds: [],
+        deps: [],
+        runner: TaskRunner.Dax,
+      }),
+      "c": new Task({
+        cmds: [],
+        deps: [],
+        runner: TaskRunner.Dax,
+      }),
+    });
+  },
+);
+
+Deno.test(
+  "run explicit",
+  async () => {
+    const tasks = await parseTasks({
+      spec: "",
+      tasks: { "start": { cmds: ["echo a", "echo b"] } },
+    });
+
+    assertEquals(tasks, {
+      "start": new Task({
+        cmds: ["echo a", "echo b"],
+        deps: [],
+        runner: TaskRunner.Dax,
+      }),
+    });
+  },
+);
+
+Deno.test(
+  "run combo",
+  async () => {
+    const tasks = await parseTasks({
+      spec: "",
+      tasks: {
+        "start > a b": { cmds: ["echo a", "echo b"], deps: ["c"] },
+        a: [],
+        b: [],
+        c: [],
+      },
+    });
+
+    assertEquals(tasks, {
+      "start": new Task({
+        cmds: ["echo a", "echo b"],
+        deps: ["a", "b", "c"],
+        runner: TaskRunner.Dax,
+      }),
+      "a": new Task({
+        cmds: [],
+        deps: [],
+        runner: TaskRunner.Dax,
+      }),
+      "b": new Task({
+        cmds: [],
+        deps: [],
+        runner: TaskRunner.Dax,
+      }),
+      "c": new Task({
+        cmds: [],
+        deps: [],
+        runner: TaskRunner.Dax,
+      }),
+    });
+  },
+);

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,0 +1,23 @@
+import { assertEquals } from "https://deno.land/std@0.171.0/testing/asserts.ts";
+import { flatten } from "../src/utils.ts";
+
+Deno.test(
+  "flatten",
+  () => {
+    const flat = flatten("APEX", {
+      str: "string",
+      num: 333,
+      config: { this: "that" },
+      arr: ["first", { inner_obj: "inner_val" }, "last"],
+    });
+
+    assertEquals(flat, {
+      "APEX_str": "string",
+      "APEX_num": "333",
+      "APEX_config_this": "that",
+      "APEX_arr_0": "first",
+      "APEX_arr_1_inner_obj": "inner_val",
+      "APEX_arr_2": "last",
+    });
+  },
+);


### PR DESCRIPTION
This PR:
- Adds tests for `apex run` and associated functionality. 
- Adds `$apex_xxx` variables to env a'la npm:

e.g., the following config:

```yaml
spec: apex.axdl
config:
  package: this_or_that
```

sets localized ENV variables like:

```sh
$apex_spec # "apex.axdl"
$apex_config_package # "this_or_that"
```
