### PR TITLE
try/catch around watch processing & install redirected template URL

### DIFF
--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,4 +1,7 @@
-import { cache } from "https://deno.land/x/cache@0.2.13/mod.ts";
+import {
+  cache,
+  remove as cacheRemove,
+} from "https://deno.land/x/cache@0.2.13/mod.ts";
 
 export async function load(location: string): Promise<Uint8Array> {
   if (location.startsWith("file:///")) {
@@ -16,4 +19,15 @@ export async function load(location: string): Promise<Uint8Array> {
     throw new Error(`could not load ${location}`);
   }
   return new Uint8Array(await response.arrayBuffer());
+}
+
+export async function remove(location: string): Promise<boolean> {
+  if (location.startsWith("file:///")) {
+    return false;
+  }
+  try {
+    return await cacheRemove(location);
+  } catch (_e) {
+    return false;
+  }
 }

--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -1,5 +1,6 @@
 import { Command } from "https://deno.land/x/cliffy@v0.25.5/command/mod.ts";
 import * as yaml from "https://deno.land/std@0.171.0/encoding/yaml.ts";
+import * as log from "https://deno.land/std@0.171.0/log/mod.ts";
 import * as path from "https://deno.land/std@0.171.0/path/mod.ts";
 
 import { Configuration } from "../config.ts";
@@ -49,20 +50,28 @@ async function watch(configurations: string[]) {
 
           let confs = specMap[p];
           if (confs) {
-            confs.forEach(async (conf) => {
-              const outputs = await processConfiguration(conf);
-              outputs.forEach((output) => writeOutput(output));
-            });
+            for (const conf of confs) {
+              try {
+                const outputs = await processConfiguration(conf);
+                outputs.forEach((output) => writeOutput(output));
+              } catch (e) {
+                log.error(e);
+              }
+            }
           }
 
           confs = configMap[p];
           if (confs) {
             watcher.close();
             await reloadConfigurations();
-            confs.forEach(async (conf) => {
-              const outputs = await processConfiguration(conf);
-              outputs.forEach((output) => writeOutput(output));
-            });
+            for (const conf of confs) {
+              try {
+                const outputs = await processConfiguration(conf);
+                outputs.forEach((output) => writeOutput(output));
+              } catch (e) {
+                log.error(e);
+              }
+            }
             return;
           }
         }

--- a/src/install.ts
+++ b/src/install.ts
@@ -9,7 +9,16 @@ export async function installTemplate(
   registry: TemplateMap,
   location: string,
 ) {
-  const url = makeRelativeUrl(location);
+  let url = makeRelativeUrl(location);
+
+  // Determine if URL redirects and possible use the
+  // location with the version included (e.g. deno.land/x).
+  if (["http", "https"].indexOf(url.protocol) != -1) {
+    const resp = await fetch(url);
+    if (resp.redirected) {
+      url = new URL(resp.url);
+    }
+  }
 
   const module = await getTemplateInfo(url.toString());
   if (module.info) {


### PR DESCRIPTION
This PR

* Prevents the watch command from erroring out when an exception is thrown from Apex parsing or code generation
* Determine if template URLs redirect to a URL with a specific version included (e.g. deno.land) so that it is obvious which version is installed, and avoids caching headaches.