### PR TITLE
Added `--list` option for `apex run` and updated readme/descriptions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Test Deno Module
+name: Apex tests
 
 on:
   push:
@@ -11,8 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: extractions/setup-just@v1
       - uses: actions/checkout@v2
       - uses: denolib/setup-deno@v2
       - name: Run tests
-        run: just test
+        run: ./apex test

--- a/README.md
+++ b/README.md
@@ -1,31 +1,40 @@
-# Apex CLI
+# Apexlang CLI
 
-Apex is an interface definition language (IDL) for modeling software. Generate
-source code, documentation, integration, everything automatically.
+The `apex` CLI is a one-stop shop for all projects across all languages.
 
-### Goals:
+It's a
 
-- <ins>A</ins>pproachable - Apex was designed from the ground up to be succinct.
-  Interfaces and data types are described using familiar syntax that won't slow
-  you down.
-- <ins>P</ins>rotocol agnostic - Regardless of the architecture, your data and
-  interfaces are fundamentally the same. Use Apex to generate code for any
-  serialization format or protocol.
-- <ins>Ex</ins>tensible - Generators are written in TypeScript. Easily add
-  custom generators that satisfy your unique needs and publish them for everyone
-  to use.
+- Project templating and scaffolding tool
+- Extensible code generation tool
+- Task runner
 
 For more information, visit [https://apexlang.io](https://apexlang.io).
 
+## Prerequisites
+
+The `apex` CLI depends on Deno.
+
+Install `deno` with instructions
+[here](https://github.com/denoland/deno_install).
+
 ## Installation
 
-First, install [Deno](https://github.com/denoland/deno_install).
-
-Then run the command below from a terminal.
+To install a release version of the `apex` CLI, run the command below:
 
 ```
 deno install -A --unstable -f -n apex https://deno.land/x/apex_cli/apex.ts
 ```
+
+To install from source, clone this repository and run `./apex run install`
+
+```sh
+git clone git@github.com:apexlang/apex.git && cd apex && ./apex install
+```
+
+## Usage
+
+Visit [https://apexlang.io](https://apexlang.io) for official documentation and
+usage.
 
 ```shell
 apex --help
@@ -59,6 +68,23 @@ Output:
     upgrade                          - Upgrade apex executable to latest or given version.
     help         [command]           - Show this help or the help of a sub-command.
     completions                      - Generate shell completions.
+```
+
+## Running tests
+
+To run tests, run the command below:
+
+```sh
+apex test
+```
+
+## Development
+
+To run the development version of apex, use the `apex` script in the root of
+this repository, e.g.
+
+```sh
+./apex help
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Output:
 
   Description:
 
-    A code generation tool using Apex, an interface definition language (IDL) for modeling software.
+    A code generation tool using Apexlang, an interface definition language (IDL) for modeling software.
 
   Options:
 
@@ -60,10 +60,10 @@ Output:
     install      <location>          - Install templates locally.
     new          <template> <dir>    - Create a new project directory using a template.
     init         <template>          - Initialize a project using a template.
-    generate     [configuration...]  - Run apex generators from a given configuration.
+    generate     [configuration...]  - Run Apexlang generators from a given configuration.
     list                             - List available resources.
     describe                         - Describe available resources.
-    watch        [configuration...]  - Watch apex configuration for changes and trigger code generation.
+    watch        [configuration...]  - Watch configuration for changes and trigger code generation.
     run          [tasks...]          - Run tasks.
     upgrade                          - Upgrade apex executable to latest or given version.
     help         [command]           - Show this help or the help of a sub-command.
@@ -80,8 +80,8 @@ apex test
 
 ## Development
 
-To run the development version of apex, use the `apex` script in the root of
-this repository, e.g.
+To run the development version of the `apex` CLI, use the `apex` script in the
+root of this repository, e.g.
 
 ```sh
 ./apex help

--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ deno install -A --unstable -f -n apex https://deno.land/x/apex_cli/apex.ts
 To install from source, clone this repository and run `./apex run install`
 
 ```sh
-git clone git@github.com:apexlang/apex.git && cd apex && ./apex install
+git clone https://github.com/apexlang/apex.git
+cd apex
+./apex install # or deno install -A --unstable ./apex.ts
 ```
 
 ## Usage

--- a/apex
+++ b/apex
@@ -1,0 +1,3 @@
+#!/bin/sh
+# deno install mocker
+exec deno run --allow-all --unstable './apex.ts' "$@"

--- a/apex.ts
+++ b/apex.ts
@@ -1,14 +1,7 @@
 #!/usr/bin/env -S deno run --allow-read --allow-write --allow-env --allow-net --allow-run --unstable
 
-import {
-  Command,
-  CompletionsCommand,
-  HelpCommand,
-} from "https://deno.land/x/cliffy@v0.25.5/command/mod.ts";
-import {
-  GithubProvider,
-  UpgradeCommand,
-} from "https://deno.land/x/cliffy@v0.25.5/command/upgrade/mod.ts";
+import { Command, CompletionsCommand, HelpCommand } from "./src/deps/cliffy.ts";
+import { GithubProvider, UpgradeCommand } from "./src/deps/cliffy.ts";
 import * as log from "https://deno.land/std@0.171.0/log/mod.ts";
 
 const LEVEL =
@@ -78,7 +71,7 @@ if (
   if (nonFlagArgs.length > 0 && !cli.getBaseCommand(args[0], true)) {
     const configPath = findApexConfig();
     if (!configPath) {
-      console.log("could not find configuration");
+      log.error("could not find configuration");
       Deno.exit(1);
     }
     let config;

--- a/apex.ts
+++ b/apex.ts
@@ -38,7 +38,7 @@ if (
     .version(version)
     .name("apex")
     .description(
-      "A code generation tool using Apex, an interface definition language (IDL) for modeling software.",
+      "A complete project tool suite based on Apexlang, an interface definition language (IDL) for modeling software.",
     )
     .command("install", install.command)
     .command("new", newCmd.command)

--- a/apex.yaml
+++ b/apex.yaml
@@ -1,0 +1,10 @@
+tasks:
+  test:
+    description: Run tests
+    cmds:
+      - deno fmt --check src/ test/
+      - deno test --unstable -A
+  install:
+    description: Install apex
+    cmds:
+      - deno install -f -A --unstable ./apex.ts

--- a/justfile
+++ b/justfile
@@ -1,7 +1,0 @@
-test:
-  deno fmt --check src/ test/
-  deno test --unstable -A test/*.test.ts
-
-install:
-  deno install -f -A --unstable ./apex.ts
-

--- a/src/commands/describe.ts
+++ b/src/commands/describe.ts
@@ -1,5 +1,5 @@
-import { Command } from "https://deno.land/x/cliffy@v0.25.5/command/mod.ts";
-import { Row, Table } from "https://deno.land/x/cliffy@v0.25.5/table/mod.ts";
+import { Command } from "../deps/cliffy.ts";
+import * as ui from "../ui.ts";
 
 import { loadTemplateRegistry } from "../utils.ts";
 import { templateCompletion } from "./utils.ts";
@@ -11,7 +11,7 @@ export const templates = new Command()
   .action(async (_options, template: string) => {
     const registry = await loadTemplateRegistry();
     const temp = registry.templates[template];
-    if (!template) {
+    if (!temp) {
       throw new Error(`template ${template} is not installed`);
     }
 
@@ -23,14 +23,7 @@ export const templates = new Command()
     const variables = temp.variables || [];
     if (variables.length > 0) {
       console.log("\nVariables:");
-      new Table()
-        .header(Row.from(["Name", "Description", "Default"]).border(true))
-        .body(
-          variables.map((
-            t,
-          ) => [t.name, t.description || "", (t.default || "").toString()]),
-        )
-        .render();
+      ui.listToTable(variables, ["description", "default"]);
     }
   });
 

--- a/src/commands/generate.ts
+++ b/src/commands/generate.ts
@@ -7,7 +7,7 @@ import { processConfiguration, writeOutput } from "../process.ts";
 
 export const command = new Command()
   .arguments("[...configuration:string[]]")
-  .description("Run apex generators from a given configuration.")
+  .description("Run Apexlang generators from a given configuration.")
   .action(async (_options: unknown, configFiles: string[]) => {
     configFiles ||= [];
     if (!configFiles.length) {

--- a/src/commands/generate.ts
+++ b/src/commands/generate.ts
@@ -1,4 +1,4 @@
-import { Command } from "https://deno.land/x/cliffy@v0.25.5/command/mod.ts";
+import { Command } from "../deps/cliffy.ts";
 import * as streams from "https://deno.land/std@0.171.0/streams/read_all.ts";
 import * as log from "https://deno.land/std@0.171.0/log/mod.ts";
 

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,4 +1,4 @@
-import { Command } from "https://deno.land/x/cliffy@v0.25.5/command/mod.ts";
+import { Command } from "../deps/cliffy.ts";
 
 import { Variables } from "../config.ts";
 import {

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -1,7 +1,7 @@
 import * as path from "https://deno.land/std@0.171.0/path/mod.ts";
 import * as yaml from "https://deno.land/std@0.171.0/encoding/yaml.ts";
 
-import { Command } from "https://deno.land/x/cliffy@v0.25.5/command/mod.ts";
+import { Command } from "../deps/cliffy.ts";
 import { getInstallDirectories } from "../utils.ts";
 import { installTemplate } from "../install.ts";
 import { TemplateMap, TemplateRegistry } from "../config.ts";

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -8,7 +8,7 @@ export const templates = new Command()
   .description("List installed templates.")
   .action(async (_options) => {
     const templates = await templateList();
-    ui.objToTable(templates, ["description"]);
+    ui.objToTable(templates, ["version", "description"]);
   });
 
 export const tasks = new Command()

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -1,19 +1,29 @@
-import { Command } from "https://deno.land/x/cliffy@v0.25.5/command/mod.ts";
-import { Row, Table } from "https://deno.land/x/cliffy@v0.25.5/table/mod.ts";
+import { Command } from "../deps/cliffy.ts";
+import { action as runAction } from "./run.ts";
 
 import { templateList } from "../utils.ts";
+import * as ui from "../ui.ts";
 
 export const templates = new Command()
   .description("List installed templates.")
   .action(async (_options) => {
     const templates = await templateList();
-    new Table()
-      .header(Row.from(["Name", "Description"]).border(true))
-      .body(templates.map((t) => [t.name, t.description]))
-      .render();
+    ui.objToTable(templates, ["description"]);
+  });
+
+export const tasks = new Command()
+  .description("List tasks.")
+  .option(
+    "-c, --config <string>",
+    "specify an Apex configuration",
+    { default: "apex.yaml" },
+  )
+  .action(async (options) => {
+    await runAction({ list: true, config: options.config }, "");
   });
 
 export const command = new Command()
   .description("List available resources.")
   .default("help")
-  .command("templates", templates);
+  .command("templates", templates)
+  .command("tasks", tasks);

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -1,4 +1,4 @@
-import { Command } from "https://deno.land/x/cliffy@v0.25.5/command/mod.ts";
+import { Command } from "../deps/cliffy.ts";
 
 import { Variables } from "../config.ts";
 import {

--- a/src/commands/utils.ts
+++ b/src/commands/utils.ts
@@ -1,4 +1,4 @@
-import { ValidationError } from "https://deno.land/x/cliffy@v0.25.5/command/mod.ts";
+import { ValidationError } from "../deps/cliffy.ts";
 import { templateList } from "../utils.ts";
 
 export const varOptions = {
@@ -23,5 +23,5 @@ export const varOptions = {
 };
 
 export async function templateCompletion(): Promise<string[]> {
-  return (await templateList()).map((t) => t.name || "");
+  return Object.values(await templateList()).map((t) => t.name || "");
 }

--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -9,7 +9,7 @@ import { processConfiguration, writeOutput } from "../process.ts";
 export const command = new Command()
   .arguments("[...configuration:string[]]")
   .description(
-    "Watch apex configuration for changes and trigger code generation.",
+    "Watch configuration for changes and trigger code generation.",
   )
   .action(async (_options: unknown, configFiles: string[]) => {
     configFiles = configFiles || [];

--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -1,4 +1,4 @@
-import { Command } from "https://deno.land/x/cliffy@v0.25.5/command/mod.ts";
+import { Command } from "../deps/cliffy.ts";
 import * as yaml from "https://deno.land/std@0.171.0/encoding/yaml.ts";
 import * as log from "https://deno.land/std@0.171.0/log/mod.ts";
 import * as path from "https://deno.land/std@0.171.0/path/mod.ts";

--- a/src/config.ts
+++ b/src/config.ts
@@ -59,6 +59,7 @@ export type TemplateMap = Record<string, InstalledTemplate>;
 
 export interface InstalledTemplate extends TemplateInfo {
   url: string;
+  version?: string;
 }
 
 export interface TemplateRegistry {

--- a/src/deps/cliffy.ts
+++ b/src/deps/cliffy.ts
@@ -1,0 +1,1 @@
+export * from "https://deno.land/x/cliffy@v0.25.7/mod.ts";

--- a/src/deps/log.ts
+++ b/src/deps/log.ts
@@ -1,0 +1,1 @@
+export * as log from "https://deno.land/std@0.171.0/log/mod.ts";

--- a/src/init.ts
+++ b/src/init.ts
@@ -9,7 +9,7 @@ import {
   InputOptions,
   Number,
   NumberOptions,
-} from "https://deno.land/x/cliffy@v0.25.5/prompt/mod.ts";
+} from "./deps/cliffy.ts";
 import * as eta from "https://deno.land/x/eta@v1.12.3/mod.ts";
 
 import {

--- a/src/task.ts
+++ b/src/task.ts
@@ -13,6 +13,7 @@ export interface CmdOutput {
 
 export class Task {
   runner = TaskRunner.Dax;
+  description?: string;
   deps: string[] = [];
   cmds: string[] = [];
 
@@ -20,6 +21,7 @@ export class Task {
     this.runner = config.runner || TaskRunner.Dax;
     this.deps = config.deps || [];
     this.cmds = config.cmds || [];
+    this.description = config.description || "";
   }
 
   async run(

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -1,0 +1,51 @@
+import { Cell, colors, Row, Table } from "./deps/cliffy.ts";
+
+export function double(value?: unknown): Cell {
+  return new Cell((value || "").toString()).colSpan(2);
+}
+
+export function primary(value: string): string {
+  return colors.bold.green(value);
+}
+
+const DOUBLE_SIZE_CELLS: (string | number | symbol)[] = ["description"];
+
+function isDoubleSize(name: string | number | symbol): boolean {
+  return DOUBLE_SIZE_CELLS.includes(name);
+}
+
+function cap(name: string | number | symbol): string {
+  const stringed = name.toString();
+  return stringed[0].toUpperCase() + stringed.slice(1);
+}
+
+export function objToTable<T>(obj: Record<string, T>, columns: (keyof T)[]) {
+  const table = new Table().minColWidth(20);
+  const header: (string | Cell)[] = ["Name"];
+
+  header.push(...columns.map((c) => isDoubleSize(c) ? double(cap(c)) : cap(c)));
+  table.header(Row.from(header).border(true));
+  if (Object.keys(obj).length === 0) {
+    table.body([Row.from([double("No results.")])]);
+  } else {
+    for (const name in obj) {
+      // deno-lint-ignore no-explicit-any
+      const row: (any | Cell)[] = [new Cell(primary(name))];
+      for (const col of columns) {
+        row.push(isDoubleSize(col) ? double(obj[name][col]) : obj[name][col]);
+      }
+      table.push(Row.from(row));
+    }
+  }
+  table.sort();
+  table.render();
+}
+
+// This turns an array of objects
+export function listToTable<T>(
+  obj: ({ name: string } & T)[],
+  columns: (keyof T)[],
+) {
+  const record = Object.fromEntries(obj.map((o) => [o["name"], o]));
+  objToTable(record, columns);
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,7 +3,7 @@ import home_dir from "https://deno.land/x/dir@1.5.1/home_dir/mod.ts";
 import * as yaml from "https://deno.land/std@0.171.0/encoding/yaml.ts";
 import * as log from "https://deno.land/std@0.171.0/log/mod.ts";
 
-import { InstalledTemplate, TemplateRegistry } from "./config.ts";
+import { Template, TemplateRegistry } from "./config.ts";
 
 // This function is copied here because it is deprecated for a reason
 // that does not match ou use case.
@@ -35,10 +35,9 @@ export async function loadTemplateRegistry(): Promise<TemplateRegistry> {
   }
 }
 
-export async function templateList(): Promise<InstalledTemplate[]> {
+export async function templateList(): Promise<Record<string, Template>> {
   const allTemplates = await loadTemplateRegistry();
-  const templates = Object.values(allTemplates.templates);
-  return templates.sort((a, b) => new String(a.name).localeCompare(b.name));
+  return allTemplates.templates;
 }
 
 export interface ApexDirs {
@@ -132,13 +131,13 @@ export function findApexConfig(config = "apex.yaml"): string | undefined {
   }
 }
 
-export function flatten(prefix: string, obj: any): any {
+export function flatten(prefix: string, obj: unknown): unknown {
   if (obj === null || obj === undefined) {
     return { [prefix]: "" };
   } else if (typeof obj === "string") {
     return { [prefix]: obj };
   } else if (Array.isArray(obj)) {
-    const result: any = {};
+    const result = {};
     for (let i = 0; i < obj.length; i++) {
       Object.assign(result, flatten(`${prefix}_${i}`, obj[i]));
     }


### PR DESCRIPTION
This PR
- adds `apex run --list` and `apex list tasks` to list out tasks
- centralized graphical table generation now that it was in a few places
- updated the readme and some descriptions to call out the major parts of the `apex` CLI.
- replaced `justfile` with `apex.yaml` and updated GH workflow to use `apex test`
- added descriptions to task definitions to make prettier `--list` output
- updated cliffy

`apex run --list` output:

![Screen Shot 2023-01-20 at 8 17 47 PM](https://user-images.githubusercontent.com/842798/213831663-d10a4551-6993-4f14-84d4-5d9ea5b99a4e.png)
