### PR TITLE
Release workflow

### DIFF
--- a/.github/workflows/release.ts
+++ b/.github/workflows/release.ts
@@ -1,0 +1,17 @@
+function env(name: string): string {
+  const val = Deno.env.get(name);
+  if (!val) throw new Error(`$${name} is required`);
+  return val;
+}
+
+const files = env("FILES").split(/\s*,\s*/);
+const version = env("VERSION");
+
+console.log("Updating versions in files");
+
+for (const file of files) {
+  console.log(`Updating ${file} for ${version}...`);
+  const orig = Deno.readTextFileSync(file);
+  const updated = orig.replace(/v\d+\.\d+\.\d+/, version);
+  Deno.writeFileSync(file, new TextEncoder().encode(updated));
+}

--- a/.github/workflows/release.ts
+++ b/.github/workflows/release.ts
@@ -7,6 +7,10 @@ function env(name: string): string {
 const files = env("FILES").split(/\s*,\s*/);
 const version = env("VERSION");
 
+if (!version.match(/^v\d+\.\d+\.\d+$/)) {
+  throw new Error("VERSION must be in the form v1.2.3");
+}
+
 console.log("Updating versions in files");
 
 for (const file of files) {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Release apex version
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release'
+        required: true
+    update_files:
+      version:
+        description: 'Files to update with version number'
+        required: true
+        default: 'apex.ts, README.md'
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: denolib/setup-deno@v2
+      - name: Update version and readme
+        env:
+          VERSION: ${{ inputs.version }}
+          FILES: ${{ inputs.files }}
+        run: |
+          deno run --allow-run --allow-env --allow-write --allow-read ./.github/workflows/release.ts
+          deno run --allow-run --allow-env --allow-write --allow-read ./.github/workflows/update-readme.ts
+      - name: Commit and tag
+        env:
+          VERSION: ${{ inputs.version }}
+        run: git add apex.ts README.md
+          echo git commit -am "$VERSION release"
+          git tag $VERSION

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,27 +6,30 @@ on:
       version:
         description: 'Version to release'
         required: true
-    update_files:
-      version:
-        description: 'Files to update with version number'
-        required: true
-        default: 'apex.ts, README.md'
+
 jobs:
   release:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: denolib/setup-deno@v2
-      - name: Update version and readme
+      - name: Update version and README.md
         env:
           VERSION: ${{ inputs.version }}
-          FILES: ${{ inputs.files }}
+          FILES: 'apex.ts,README.md'
         run: |
           deno run --allow-run --allow-env --allow-write --allow-read ./.github/workflows/release.ts
           deno run --allow-run --allow-env --allow-write --allow-read ./.github/workflows/update-readme.ts
-      - name: Commit and tag
-        env:
-          VERSION: ${{ inputs.version }}
-        run: git add apex.ts README.md
-          echo git commit -am "$VERSION release"
-          git tag $VERSION
+      - name: Commit and tag release
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: ${{ inputs.version }} release
+          tagging_message: ${{ inputs.version }}
+      - name: Create Release
+        uses: ncipollo/release-action@v1.12.0
+        with:
+          generateReleaseNotes: true
+          makeLatest: true
+          tag: ${{ inputs.version }}

--- a/.github/workflows/update-readme.ts
+++ b/.github/workflows/update-readme.ts
@@ -1,0 +1,21 @@
+const readme = "README.md";
+
+console.log(`Updating ${readme} examples`);
+const orig = Deno.readTextFileSync(readme);
+
+const colorCodes = /\x1b\[\d+;*m/g;
+const upgradeNotification = /\(New version.*$/m;
+
+const apexOutput = await Deno.run({ stdout: "piped", cmd: ["./apex", "help"] })
+  .output();
+
+const helpText = new TextDecoder().decode(apexOutput)
+  .replace(colorCodes, "")
+  .replace(upgradeNotification, "");
+
+const updated = orig.replace(
+  /```(console{title="apex help"}).*?```/s,
+  `\`\`\`$1${helpText}\`\`\``,
+);
+
+Deno.writeFileSync(`readme.new.md`, new TextEncoder().encode(updated));

--- a/.github/workflows/update-readme.ts
+++ b/.github/workflows/update-readme.ts
@@ -6,10 +6,13 @@ const orig = Deno.readTextFileSync(readme);
 const colorCodes = /\x1b\[\d+;*m/g;
 const upgradeNotification = /\(New version.*$/m;
 
-const apexOutput = await Deno.run({ stdout: "piped", cmd: ["./apex", "help"] })
-  .output();
+const apexOutput = await Deno.run({
+  stdout: "piped",
+  cmd: ["./apex", "help"],
+}).output();
 
-const helpText = new TextDecoder().decode(apexOutput)
+const helpText = new TextDecoder()
+  .decode(apexOutput)
   .replace(colorCodes, "")
   .replace(upgradeNotification, "");
 
@@ -18,4 +21,4 @@ const updated = orig.replace(
   `\`\`\`$1${helpText}\`\`\``,
 );
 
-Deno.writeFileSync(`readme.new.md`, new TextEncoder().encode(updated));
+Deno.writeFileSync(readme, new TextEncoder().encode(updated));

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Install `deno` with instructions
 To install a release version of the `apex` CLI, run the command below:
 
 ```
-deno install -A --unstable -f -n apex https://deno.land/x/apex_cli/apex.ts
+deno install -A --unstable -f -n apex https://deno.land/x/apex_cli@v0.0.15/apex.ts
 ```
 
 To install from source, clone this repository and run `./apex run install`
@@ -44,7 +44,7 @@ apex --help
 
 Output:
 
-```
+```console{title="apex help"}
   Usage:   apex
   Version: v0.0.12
 

--- a/apex.ts
+++ b/apex.ts
@@ -22,7 +22,7 @@ import { findApexConfig, setupLogger } from "./src/utils.ts";
 import { parseConfigYaml } from "./src/config.ts";
 
 // Version bump this on release.
-const version = "v0.0.16";
+const version = "v0.0.15";
 
 const args = Deno.args;
 


### PR DESCRIPTION
Added GH action workflow to automatically:
- update `README.md` and `apex.ts` version numbers
- update `README.md` help output with the latest help output
- commit and tag with the version
- create a release.