### PR TITLE
Various template version fixes

### DIFF
--- a/src/cache.ts
+++ b/src/cache.ts
@@ -4,7 +4,7 @@ import {
 } from "https://deno.land/x/cache@0.2.13/mod.ts";
 
 export async function load(location: string): Promise<Uint8Array> {
-  if (location.startsWith("file:///")) {
+  if (location.startsWith("file:///") || location.startsWith(".")) {
     return Deno.readFileSync(new URL(location));
   }
 

--- a/src/install.ts
+++ b/src/install.ts
@@ -13,7 +13,7 @@ export async function installTemplate(
 
   // Determine if URL redirects and possible use the
   // location with the version included (e.g. deno.land/x).
-  if (["http", "https"].indexOf(url.protocol) != -1) {
+  if (["http:", "https:"].indexOf(url.protocol) != -1) {
     const resp = await fetch(url);
     if (resp.redirected) {
       url = new URL(resp.url);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -37,13 +37,13 @@ export async function loadTemplateRegistry(): Promise<TemplateRegistry> {
   }
 }
 
-const versionRegex = /@(v[0-9][^\/]*)\//gm;
-
 function calulateVersions(registry: TemplateRegistry) {
   for (const tmpl of Object.values(registry.templates)) {
     if (tmpl.version) {
       continue;
     }
+
+    const versionRegex = /@(v[0-9][^\/]*)\//g;
 
     // Get version
     let m;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -43,7 +43,7 @@ function calulateVersions(registry: TemplateRegistry) {
       continue;
     }
 
-    const versionRegex = /@(v[0-9][^\/]*)\//g;
+    const versionRegex = /@(v[0-9][.0-9a-zA-Z\-_^\/]*)\//g;
 
     // Get version
     let m;


### PR DESCRIPTION
This PR fixes various template version issues:

* Fix protocol literals to match the URL
* Move regex const inside calculateVersions so that it matches every iteration
* Add `startsWith(".")` check to cache.load to better detect local file paths local files

To add tests for this, we would need to install a remote template URL. The best candidate would be to install from apexlang/codegen, however, the templates there still use the old format. Given that, I recommend a follow up PR after apexlang/codegen has been "upgraded" to programmatic templates.