### PR TITLE
Added `--reload` option to tasks to refresh cache

### DIFF
--- a/src/commands/generate.ts
+++ b/src/commands/generate.ts
@@ -3,20 +3,31 @@ import * as streams from "https://deno.land/std@0.171.0/streams/read_all.ts";
 import * as log from "https://deno.land/std@0.171.0/log/mod.ts";
 
 import { Configuration, Output, parseConfigYaml } from "../config.ts";
-import { processConfiguration, writeOutput } from "../process.ts";
+import {
+  processConfiguration,
+  ProcessOptions,
+  writeOutput,
+} from "../process.ts";
 
 export const command = new Command()
   .arguments("[...configuration:string[]]")
   .description("Run Apexlang generators from a given configuration.")
-  .action(async (_options: unknown, configFiles: string[]) => {
+  .option(
+    "-r, --reload",
+    "reload files from cache",
+  )
+  .action(async (options: ProcessOptions, configFiles: string[]) => {
     configFiles ||= [];
     if (!configFiles.length) {
       configFiles = ["apex.yaml"];
     }
-    await fromFiles(...configFiles);
+    await fromFiles(configFiles, options);
   });
 
-export async function fromFiles(...configFiles: string[]) {
+export async function fromFiles(
+  configFiles: string[],
+  options: ProcessOptions,
+) {
   for (const configFile of configFiles) {
     let configContents = "";
     try {
@@ -26,21 +37,24 @@ export async function fromFiles(...configFiles: string[]) {
       throw e;
     }
     const configs = parseConfigYaml(configContents);
-    await fromConfigs(configs);
+    await fromConfigs(configs, options);
   }
 }
 
-export async function fromStdin() {
+export async function fromStdin(options: ProcessOptions = {}) {
   const stdinContent = await streams.readAll(Deno.stdin);
   const content = new TextDecoder().decode(stdinContent);
   const configs = parseConfigYaml(content);
-  await fromConfigs(configs);
+  await fromConfigs(configs, options);
 }
 
-export async function fromConfigs(configs: Configuration[]) {
+export async function fromConfigs(
+  configs: Configuration[],
+  options: ProcessOptions,
+) {
   const outputs: Output[] = [];
   for (const config of configs) {
-    const o = await processConfiguration(config);
+    const o = await processConfiguration(config, options);
     outputs.push(...o);
   }
 

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -11,6 +11,10 @@ import { log } from "../deps/log.ts";
 export const command = new Command()
   .complete("template", async () => await templateCompletion())
   .arguments("<template:string>")
+  .option(
+    "-r, --reload",
+    "ignore cache and reload sources",
+  )
   .option("-v, --var <item:string>", "define a template variable", varOptions)
   .option(
     "-p, --path <string>",
@@ -33,6 +37,7 @@ export const command = new Command()
         false,
         ".",
         template,
+        options,
         options.spec,
         vars || {},
       );

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -13,6 +13,10 @@ export const command = new Command()
   .arguments("<template:string> <dir:string>")
   .option("-v, --var <item:string>", "define a template variable", varOptions)
   .option(
+    "-r, --reload",
+    "ignore cache and reload sources",
+  )
+  .option(
     "-p, --path <string>",
     "specify a relative path to the template root",
     { default: "" },
@@ -33,6 +37,7 @@ export const command = new Command()
         true,
         dir,
         template,
+        options,
         options.spec,
         vars || {},
       );

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -4,7 +4,7 @@ import { fromConfigs } from "./generate.ts";
 import * as ui from "../ui.ts";
 
 import { Configuration, findConfigFile, parseConfigYaml } from "../config.ts";
-import { processPlugins } from "../process.ts";
+import { ProcessOptions, processPlugins } from "../process.ts";
 import { flatten } from "../utils.ts";
 import { CmdOutput, Task } from "../task.ts";
 
@@ -13,6 +13,7 @@ export interface RunOptions {
   quiet?: boolean;
   failUndefined?: boolean;
   list?: boolean;
+  reload?: boolean;
 }
 
 export const command = new Command()
@@ -44,7 +45,7 @@ export async function action(
   const config = await findConfigFile(options.config);
   const configs = parseConfigYaml(config);
   for (const cfg of configs) {
-    const taskMap = await loadTasks(cfg);
+    const taskMap = await loadTasks(cfg, options);
     if (options.list) {
       ui.objToTable(taskMap, ["description"]);
       continue;
@@ -98,8 +99,9 @@ export function parseTasks(
 
 export async function loadTasks(
   config: Configuration,
+  options: ProcessOptions,
 ): Promise<Record<string, Task>> {
-  config = await processPlugins(config);
+  config = await processPlugins(config, options);
   return parseTasks(config);
 }
 
@@ -145,7 +147,7 @@ async function run(
   if (!t) {
     if (task == "generate") {
       console.log("%capex generate", "font-weight: bold");
-      await fromConfigs([config]);
+      await fromConfigs([config], opts);
       return;
     }
 

--- a/src/init.ts
+++ b/src/init.ts
@@ -20,7 +20,7 @@ import {
   Variables,
 } from "./config.ts";
 import { asBytes } from "./utils.ts";
-import { writeOutput } from "./process.ts";
+import { ProcessOptions, writeOutput } from "./process.ts";
 import {
   existsSync,
   getInstallDirectories,
@@ -278,6 +278,7 @@ export async function initializeProjectFromTemplate(
   isNew: boolean,
   dir: string,
   template: string,
+  options: ProcessOptions,
   spec?: string,
   variables: Variables = {},
 ): Promise<void> {
@@ -307,7 +308,7 @@ export async function initializeProjectFromTemplate(
 
   log.debug(`Initializing project from template ${url}`);
 
-  const templateModule = await getTemplateInfo(url.toString());
+  const templateModule = await getTemplateInfo(url.toString(), options);
   if (!templateModule.info) {
     throw new Error("template module does not contain info");
   }
@@ -370,7 +371,7 @@ export async function initializeProjectFromTemplate(
   // Default to name variable to directory name.
   variables.name = variables.name || path.basename(path.resolve(dir));
 
-  const fsstructure = await processTemplate(template, variables);
+  const fsstructure = await processTemplate(template, variables, options);
 
   // Add dynamic variables
   if (fsstructure.variables) {

--- a/src/install.ts
+++ b/src/install.ts
@@ -1,6 +1,6 @@
 import * as log from "https://deno.land/std@0.171.0/log/mod.ts";
 
-import { getTemplateInfo, processTemplate } from "./process.ts";
+import { getTemplateInfo, ProcessOptions, processTemplate } from "./process.ts";
 import { makeRelativeUrl } from "./utils.ts";
 import * as cache from "./cache.ts";
 import { FSStructure, TemplateMap } from "./config.ts";
@@ -8,6 +8,7 @@ import { FSStructure, TemplateMap } from "./config.ts";
 export async function installTemplate(
   registry: TemplateMap,
   location: string,
+  options: ProcessOptions,
 ) {
   let url = makeRelativeUrl(location);
 
@@ -20,14 +21,14 @@ export async function installTemplate(
     }
   }
 
-  const module = await getTemplateInfo(url.toString());
+  const module = await getTemplateInfo(url.toString(), options);
   if (module.info) {
     // Cache possible files
     let structure: FSStructure | undefined;
     try {
       structure = await processTemplate(url.toString(), {
         "cache": true,
-      });
+      }, options);
     } catch (_err) {
       // Ignore
     }
@@ -75,6 +76,6 @@ export async function installTemplate(
       template = "./" + template;
     }
     const nestedURL = new URL(template, url);
-    await installTemplate(registry, nestedURL.toString());
+    await installTemplate(registry, nestedURL.toString(), options);
   }
 }

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -18,7 +18,7 @@ Deno.test(
           visitorClass: "RustBasic",
         },
       },
-    });
+    }, { reload: true });
 
     const fixture = await Deno.readTextFile(path.join(__dirname, "fixture.rs"));
     assertEquals(generated, [

--- a/test/run.test.ts
+++ b/test/run.test.ts
@@ -12,7 +12,9 @@ async function runFixture(
   task: string,
   env: Record<string, string> = {},
 ): Promise<Uint8Array> {
-  return runApex(["run", "--config", config, "--quiet", task], env);
+  const cmd = ["run", "--config", config, "--quiet"];
+  if (task) cmd.push(task);
+  return runApex(cmd, env);
 }
 
 function doTest(def: TestDef) {
@@ -92,6 +94,11 @@ const tests: TestDef[] = [
   {
     fixture: "test/fixtures/task-hello-world.yaml",
     task: "test",
+    expected: "Hello World\n",
+  },
+  {
+    fixture: "test/fixtures/task-hello-world.yaml",
+    task: "",
     expected: "Hello World\n",
   },
   {

--- a/test/template.test.ts
+++ b/test/template.test.ts
@@ -11,6 +11,7 @@ Deno.test(
     const generated = await processTemplate(
       path.join(__dirname, "template", "template.ts"),
       {},
+      {},
     );
 
     assertEquals(generated, {


### PR DESCRIPTION
This PR:
- Adds a `--reload` option to tasks that run plugins, generators, and templates so the user can optionally choose to refresh cache.


Note: 
The `apex.ts` changes are to de-dupe the `apex run` logic to make the arguments to `--run` consistent. The default behavior when arguments are passed and non of the non-flag options match a built-in is to now treat it as a full `apex run` command.