### PR TITLE
Fix version regex and missing options

### DIFF
--- a/src/commands/generate.ts
+++ b/src/commands/generate.ts
@@ -21,7 +21,7 @@ export const command = new Command()
     if (!configFiles.length) {
       configFiles = ["apex.yaml"];
     }
-    await fromFiles(configFiles, options);
+    await fromFiles(configFiles, options || {});
   });
 
 export async function fromFiles(

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -30,8 +30,11 @@ export const command = new Command()
     "apex specification to use for the project",
   )
   .description("Initialize a project using a template.")
-  .action(async (options, template: string) => {
-    const vars = (options || {}).var || ({} as Variables);
+  .action(async (options, template) => {
+    options ||= {
+      path: "",
+    };
+    const vars = options.var || ({} as Variables);
     try {
       await initializeProjectFromTemplate(
         false,

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -9,9 +9,13 @@ import { TemplateMap, TemplateRegistry } from "../config.ts";
 export const command = new Command()
   .arguments("<location:string>")
   .description("Install templates locally.")
-  .action(async (_options, location: string) => {
+  .option(
+    "-r, --reload",
+    "ignore cache and reload sources",
+  )
+  .action(async (options, location: string) => {
     const updates: TemplateMap = {};
-    await installTemplate(updates, location);
+    await installTemplate(updates, location, options || {});
 
     if (Object.keys(updates).length == 0) {
       return;

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -30,8 +30,11 @@ export const command = new Command()
     "apex specification to use for the project",
   )
   .description("Create a new project directory using a template.")
-  .action(async (options, template: string, dir: string) => {
-    const vars = (options || {}).var || ({} as Variables);
+  .action(async (options, template, dir) => {
+    options ||= {
+      path: "",
+    };
+    const vars = options.var || ({} as Variables);
     try {
       await initializeProjectFromTemplate(
         true,

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -42,6 +42,7 @@ export async function action(
   options: RunOptions,
   ...tasks: string[]
 ) {
+  options ||= {};
   const config = await findConfigFile(options.config);
   const configs = parseConfigYaml(config);
   for (const cfg of configs) {

--- a/src/process.ts
+++ b/src/process.ts
@@ -183,6 +183,7 @@ async function processGeneric<I, O>(
   config: I,
   options: ProcessOptions,
 ): Promise<O> {
+  options ||= {};
   log.debug(`Input is: ${JSON.stringify(config, null, 2)}`);
 
   // Run the generation process with restricted permissions.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -43,7 +43,7 @@ function calulateVersions(registry: TemplateRegistry) {
       continue;
     }
 
-    const versionRegex = /@(v[0-9][.0-9a-zA-Z\-_^\/]*)\//g;
+    const versionRegex = /@(v[0-9][.0-9a-zA-Z\-_^\/]*?)\//s;
 
     // Get version
     let m;


### PR DESCRIPTION
This fixes the undefined options and broken regex. There's a `globalOptions()` method in cliffy we should look into. It didn't work how I expected out-of-the-box but it's what we need for an option like this.