### PR TITLE
Fixes around preserving user configuration

### DIFF
--- a/apex.yaml
+++ b/apex.yaml
@@ -3,6 +3,8 @@ tasks:
     description: Run tests
     cmds:
       - deno fmt --check src/ test/
+      - deno lint src/
+      - deno check --unstable apex.ts
       - deno test --unstable -A
   install:
     description: Install apex

--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -105,12 +105,13 @@ async function watch(configurations: string[], options: ProcessOptions) {
         confs1.push(c.config);
         configMapNew[c.path] = confs1;
 
-        // const specPath = path.resolve(path.join(c.dir, c.config.spec));
-        const specPath = path.resolve(c.config.spec);
-        watchPaths.add(specPath);
-        const confs = specMapNew[specPath] || [];
-        confs.push(c.config);
-        specMapNew[specPath] = confs;
+        if (c.config.spec) {
+          const specPath = path.resolve(c.config.spec);
+          watchPaths.add(specPath);
+          const confs = specMapNew[specPath] || [];
+          confs.push(c.config);
+          specMapNew[specPath] = confs;
+        }
       });
 
       configMap = configMapNew;

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,7 +8,7 @@ export type Config = { [key: string]: unknown };
 /// MAIN CONFIG
 
 export interface Configuration {
-  spec: string;
+  spec?: string;
   config?: Config;
   plugins?: string[];
   generates?: Record<string, Target>;

--- a/test/fixtures/task-apex-env.yaml
+++ b/test/fixtures/task-apex-env.yaml
@@ -1,4 +1,4 @@
-spec: 'my-spec.yaml'
+spec: '../test.axdl'
 config:
   some_val: 12345
 tasks:

--- a/test/run.test.ts
+++ b/test/run.test.ts
@@ -127,7 +127,7 @@ const tests: TestDef[] = [
   {
     fixture: "test/fixtures/task-apex-env.yaml",
     task: "test",
-    expected: "My spec is my-spec.yaml and some_val is 12345\n",
+    expected: "My spec is ../test.axdl and some_val is 12345\n",
   },
 ];
 

--- a/test/test-plugin.ts
+++ b/test/test-plugin.ts
@@ -19,9 +19,12 @@ export default function (
       module: generator,
     };
   }
+  config.config ||= {};
+  config.config.value = "from-plugin";
+  config.config.name = "from-plugin";
 
   config.tasks ||= {};
-  config.tasks["start"] = [`echo "test"`];
+  config.tasks["build"] = [`echo "from-plugin"`];
 
   return config;
 }

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,5 +1,6 @@
 import { assertEquals } from "https://deno.land/std@0.171.0/testing/asserts.ts";
-import { flatten } from "../src/utils.ts";
+import { Configuration } from "../src/config.ts";
+import { flatten, merge, mergeConfigurations } from "../src/utils.ts";
 
 Deno.test(
   "flatten",
@@ -18,6 +19,62 @@ Deno.test(
       "APEX_arr_0": "first",
       "APEX_arr_1_inner_obj": "inner_val",
       "APEX_arr_2": "last",
+    });
+  },
+);
+
+Deno.test(
+  "mergeConfiguration",
+  () => {
+    const orig: Configuration = {
+      config: { value: "original" },
+      generates: {
+        "original.txt": { module: "original.ts" },
+      },
+      tasks: {
+        original: ["echo 'original'"],
+      },
+    };
+    const plugin: Configuration = {
+      config: { name: "from-plugin", value: "plugin", other: "plugin" },
+      generates: {
+        "original.txt": { module: "plugin.ts" },
+        "plugin.txt": { module: "plugin.ts" },
+      },
+      tasks: {
+        original: ["echo 'plugin'"],
+      },
+    };
+
+    const finalConfig = mergeConfigurations(orig, plugin);
+
+    assertEquals(finalConfig, {
+      config: { name: "from-plugin", value: "original", other: "plugin" },
+      generates: {
+        "original.txt": { module: "original.ts" },
+        "plugin.txt": { module: "plugin.ts" },
+      },
+      tasks: {
+        original: ["echo 'original'"],
+      },
+    });
+  },
+);
+
+Deno.test(
+  "merge",
+  () => {
+    const orig = {
+      name: undefined,
+    };
+    const plugin = {
+      name: "from-plugin",
+    };
+
+    const finalConfig = merge(orig, plugin);
+
+    assertEquals(finalConfig, {
+      name: "from-plugin",
     });
   },
 );


### PR DESCRIPTION
This PR:
- Fixes #30 
- Retains the original user configuration and uses it to override generated configuration values with the same name.
- Adds a bunch of tests around this behavior.
- Adds linting and type checking to the test task