### PR TITLE
Removed task shorthand, fixed #33

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -172,10 +172,10 @@ export function mergeConfigurations(
     base.generates || {},
     addon.generates || {},
   );
-  // Don't add task merging here.
-  // The task shorthand (e.g. "task > dep1 dep2") makes it impossible to
-  // merge properly until tasks are parsed. If we merge them in advance here
-  // we lose track of which takes precedence.
+  base.tasks = merge(
+    base.tasks || {},
+    addon.tasks || {},
+  );
   return base;
 }
 
@@ -183,15 +183,22 @@ export function merge<T>(
   base: Record<string, T>,
   addon: Record<string, T>,
 ): Record<string, T> {
-  for (const key of Object.keys(addon)) {
-    const value = base[key];
+  // normalize input keys by trimming whitespace.
+  const trimmedBase: Record<string, T> = Object.fromEntries(
+    Object.entries(base).map(([k, v]) => [k.trim(), v]),
+  );
+  const trimmedAddon: Record<string, T> = Object.fromEntries(
+    Object.entries(addon).map(([k, v]) => [k.trim(), v]),
+  );
+  for (const key of Object.keys(trimmedAddon)) {
+    const value = trimmedBase[key];
     const isOriginalUnset = value === null || value === undefined ||
       value === "";
     if (isOriginalUnset) {
-      base[key] = addon[key];
+      trimmedBase[key] = trimmedAddon[key];
     }
   }
-  return base;
+  return trimmedBase;
 }
 
 export function flatten(prefix: string, obj: unknown): unknown {

--- a/test/fixtures/task-deps.yaml
+++ b/test/fixtures/task-deps.yaml
@@ -1,6 +1,8 @@
 spec: ''
 tasks:
-  test > b:
-    - echo Hello World
+  test:
+    deps: ['b']
+    cmds:
+      - echo Hello World
   b:
     - echo "From b"

--- a/test/fixtures/task-refs.yaml
+++ b/test/fixtures/task-refs.yaml
@@ -1,7 +1,9 @@
 spec: ''
 tasks:
-  test > b:
-    - echo Hello World
+  test:
+    deps: ['b']
+    cmds:
+      - echo Hello World
   c: &c
     - 'echo From c'
   b: *c

--- a/test/regression.test.ts
+++ b/test/regression.test.ts
@@ -1,0 +1,32 @@
+import * as apex from "https://deno.land/x/apex_core@v0.1.3/mod.ts";
+import { assertEquals } from "https://deno.land/std@0.171.0/testing/asserts.ts";
+import { processConfig, processPlugin } from "../src/generate.ts";
+import * as path from "https://deno.land/std@0.171.0/path/mod.ts";
+import { asBytes, setupLogger } from "../src/utils.ts";
+import { Configuration } from "../src/config.ts";
+
+const __dirname = new URL(".", import.meta.url).pathname;
+const spec = path.join(__dirname, "test.axdl");
+const plugin = path.join(__dirname, "test-plugin.ts");
+const generator = path.join(__dirname, "test-generator.ts");
+await setupLogger("DEBUG");
+
+Deno.test(
+  "regression test for #33",
+  { permissions: { read: true, net: true, run: true } },
+  async () => {
+    const apexSource = await Deno.readTextFile(spec);
+    const doc = apex.parse(apexSource);
+    const config = await processPlugin(doc, {
+      spec,
+      plugins: [
+        "https://raw.githubusercontent.com/nanobus/iota/5aec377a326c7f04ae4c37a5e1dfaaf9ea5c3e92/codegen/src/tinygo/plugin.ts",
+      ],
+    });
+
+    assertEquals(config.tasks?.all, {
+      deps: ["clean", "generate", "deps", "build"],
+      description: "Clean, generate, and build",
+    });
+  },
+);

--- a/test/tasks.test.ts
+++ b/test/tasks.test.ts
@@ -31,7 +31,11 @@ Deno.test(
   async () => {
     const tasks = await loadTasks({
       plugins: [plugin],
-      tasks: { "build > dep": [`echo "original"`], dep: [] },
+      tasks: {
+        // note: the extra whitespace in 'build ' is intentional.
+        "build ": { cmds: [`echo "original"`], deps: ["dep"] },
+        dep: [],
+      },
     }, { reload: false });
 
     assertEquals(tasks, {
@@ -52,39 +56,6 @@ Deno.test(
 );
 
 Deno.test(
-  "run a > b shorthand",
-  async () => {
-    const tasks = await parseTasks({
-      spec: "",
-      tasks: { "start > a b c": [`echo "test"`], a: [], b: [], c: [] },
-    });
-
-    assertEquals(tasks, {
-      "start": new Task({
-        cmds: [`echo "test"`],
-        deps: ["a", "b", "c"],
-        runner: TaskRunner.Dax,
-      }),
-      "a": new Task({
-        cmds: [],
-        deps: [],
-        runner: TaskRunner.Dax,
-      }),
-      "b": new Task({
-        cmds: [],
-        deps: [],
-        runner: TaskRunner.Dax,
-      }),
-      "c": new Task({
-        cmds: [],
-        deps: [],
-        runner: TaskRunner.Dax,
-      }),
-    });
-  },
-);
-
-Deno.test(
   "run explicit",
   async () => {
     const tasks = await parseTasks({
@@ -95,44 +66,6 @@ Deno.test(
     assertEquals(tasks, {
       "start": new Task({
         cmds: ["echo a", "echo b"],
-        deps: [],
-        runner: TaskRunner.Dax,
-      }),
-    });
-  },
-);
-
-Deno.test(
-  "run combo",
-  async () => {
-    const tasks = await parseTasks({
-      spec: "",
-      tasks: {
-        "start > a b": { cmds: ["echo a", "echo b"], deps: ["c"] },
-        a: [],
-        b: [],
-        c: [],
-      },
-    });
-
-    assertEquals(tasks, {
-      "start": new Task({
-        cmds: ["echo a", "echo b"],
-        deps: ["a", "b", "c"],
-        runner: TaskRunner.Dax,
-      }),
-      "a": new Task({
-        cmds: [],
-        deps: [],
-        runner: TaskRunner.Dax,
-      }),
-      "b": new Task({
-        cmds: [],
-        deps: [],
-        runner: TaskRunner.Dax,
-      }),
-      "c": new Task({
-        cmds: [],
         deps: [],
         runner: TaskRunner.Dax,
       }),

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -66,15 +66,18 @@ Deno.test(
   () => {
     const orig = {
       name: undefined,
+      " other ": "original",
     };
     const plugin = {
       name: "from-plugin",
+      other: "from-plugin",
     };
 
     const finalConfig = merge(orig, plugin);
 
     assertEquals(finalConfig, {
       name: "from-plugin",
+      other: "original",
     });
   },
 );


### PR DESCRIPTION
This PR:
- removes `task > dep` shorthand
- fixes #33 
- adds regression test for task config from plugins. 