### PR TITLE
Add "scaffold" option for generated files

### DIFF
--- a/.github/workflows/update-readme.ts
+++ b/.github/workflows/update-readme.ts
@@ -16,11 +16,14 @@ const apexOutput = outout.stdout;
 const helpText = new TextDecoder()
   .decode(apexOutput)
   .replace(colorCodes, "")
-  .replace(upgradeNotification, "");
+  .replace(upgradeNotification, "")
+  .trim();
 
 const updated = orig.replace(
   /```(console{title="apex help"}).*?```/s,
-  `\`\`\`$1${helpText}\`\`\``,
+  `\`\`\`\$1
+${helpText}
+\`\`\``,
 );
 
 Deno.writeFileSync(readme, new TextEncoder().encode(updated));

--- a/.github/workflows/update-readme.ts
+++ b/.github/workflows/update-readme.ts
@@ -6,10 +6,12 @@ const orig = Deno.readTextFileSync(readme);
 const colorCodes = /\x1b\[\d+;*m/g;
 const upgradeNotification = /\(New version.*$/m;
 
-const apexOutput = await Deno.run({
+const command = new Deno.Command("./apex", {
   stdout: "piped",
-  cmd: ["./apex", "help"],
-}).output();
+  args: ["help"],
+});
+const outout = await command.output();
+const apexOutput = outout.stdout;
 
 const helpText = new TextDecoder()
   .decode(apexOutput)

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ apex --help
 
 Output:
 
-````console{title="apex help"}
+```console{title="apex help"}
 Usage:   apex  
   Version: v0.1.0
 
@@ -78,7 +78,7 @@ To run tests, run the command below:
 
 ```sh
 apex test
-````
+```
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,34 @@ apex --help
 
 Output:
 
-```console{title="apex help"}```
+```console{title="apex help"}
+  Usage:   apex  
+  Version: v0.1.0
+
+  Description:
+
+    A complete project tool suite based on Apexlang, an interface definition language (IDL) for modeling software.
+
+  Options:
+
+    -h, --help     - Show this help.                            
+    -V, --version  - Show the version number for this program.  
+
+  Commands:
+
+    install      <location>          - Install templates locally.                                  
+    new          <template> <dir>    - Create a new project directory using a template.            
+    init         <template>          - Initialize a project using a template.                      
+    generate     [configuration...]  - Run Apexlang generators from a given configuration.         
+    list                             - List available resources.                                   
+    describe                         - Describe available resources.                               
+    watch        [configuration...]  - Watch configuration for changes and trigger code generation.
+    run          [tasks...]          - Run tasks.                                                  
+    upgrade                          - Upgrade apex executable to latest or given version.         
+    help         [command]           - Show this help or the help of a sub-command.                
+    completions                      - Generate shell completions.                                 
+
+```
 
 ## Running tests
 

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ apex --help
 
 Output:
 
-```console{title="apex help"}
-  Usage:   apex  
+````console{title="apex help"}
+Usage:   apex  
   Version: v0.1.0
 
   Description:
@@ -69,8 +69,7 @@ Output:
     run          [tasks...]          - Run tasks.                                                  
     upgrade                          - Upgrade apex executable to latest or given version.         
     help         [command]           - Show this help or the help of a sub-command.                
-    completions                      - Generate shell completions.                                 
-
+    completions                      - Generate shell completions.
 ```
 
 ## Running tests
@@ -79,7 +78,7 @@ To run tests, run the command below:
 
 ```sh
 apex test
-```
+````
 
 ## Development
 

--- a/apex.ts
+++ b/apex.ts
@@ -2,7 +2,7 @@
 
 import { Command, CompletionsCommand, HelpCommand } from "./src/deps/cliffy.ts";
 import { GithubProvider, UpgradeCommand } from "./src/deps/cliffy.ts";
-import * as log from "https://deno.land/std@0.171.0/log/mod.ts";
+import * as log from "https://deno.land/std@0.192.0/log/mod.ts";
 
 const LEVEL =
   (Deno.env.get("APEX_LOG")?.toUpperCase() as log.LevelName | undefined) ||
@@ -67,8 +67,8 @@ if (
     .command("completions", new CompletionsCommand());
 
   const nonFlagArgs = args.filter((v) => !v.startsWith("-"));
-  const nonApexCommand =
-    (nonFlagArgs.length > 0 && !cli.getBaseCommand(args[0], true));
+  const nonApexCommand = nonFlagArgs.length > 0 &&
+    !cli.getBaseCommand(args[0], true);
   // If we have a subcommand that isn't a built-in, treat
   // the command as if it were triggered with `apex run`
   if (nonApexCommand) {

--- a/src/astyle.ts
+++ b/src/astyle.ts
@@ -1,4 +1,4 @@
-import { default as WASI } from "https://deno.land/std@0.171.0/wasi/snapshot_preview1.ts";
+import { default as WASI } from "https://deno.land/std@0.192.0/wasi/snapshot_preview1.ts";
 import { cache } from "https://deno.land/x/cache@0.2.13/mod.ts";
 import { decode, encode } from "./utf8.ts";
 

--- a/src/commands/generate.ts
+++ b/src/commands/generate.ts
@@ -1,6 +1,6 @@
 import { Command } from "../deps/cliffy.ts";
-import * as streams from "https://deno.land/std@0.171.0/streams/read_all.ts";
-import * as log from "https://deno.land/std@0.171.0/log/mod.ts";
+import * as streams from "https://deno.land/std@0.192.0/streams/read_all.ts";
+import * as log from "https://deno.land/std@0.192.0/log/mod.ts";
 
 import { Configuration, Output, parseConfigYaml } from "../config.ts";
 import {
@@ -12,6 +12,10 @@ import {
 export const command = new Command()
   .arguments("[...configuration:string[]]")
   .description("Run Apexlang generators from a given configuration.")
+  .option(
+    "-s, --scaffold",
+    "generate scaffolded files",
+  )
   .option(
     "-r, --reload",
     "reload files from cache",

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -1,5 +1,5 @@
-import * as path from "https://deno.land/std@0.171.0/path/mod.ts";
-import * as yaml from "https://deno.land/std@0.171.0/encoding/yaml.ts";
+import * as path from "https://deno.land/std@0.192.0/path/mod.ts";
+import * as yaml from "https://deno.land/std@0.192.0/yaml/mod.ts";
 
 import { Command } from "../deps/cliffy.ts";
 import { getInstallDirectories } from "../utils.ts";

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -1,5 +1,5 @@
 import { Command } from "../deps/cliffy.ts";
-import * as log from "https://deno.land/std@0.171.0/log/mod.ts";
+import * as log from "https://deno.land/std@0.192.0/log/mod.ts";
 import { fromConfigs } from "./generate.ts";
 import * as ui from "../ui.ts";
 
@@ -49,7 +49,7 @@ export async function action(
     const taskMap = await loadTasks(cfg, options);
     if (options.list) {
       ui.objToTable(taskMap, ["description"]);
-      continue;
+      return;
     }
     await runTasks(
       cfg,
@@ -68,15 +68,8 @@ export function parseTasks(
   const taskMap: Record<string, Task> = {};
 
   for (const key of Object.keys(config.tasks)) {
-    let task;
     const def = config.tasks[key];
-    if (Array.isArray(def)) {
-      task = new Task({ cmds: def });
-    } else {
-      task = new Task(def);
-    }
-
-    taskMap[key] = task;
+    taskMap[key] = new Task(def);
   }
 
   return taskMap;

--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -1,7 +1,7 @@
 import { Command } from "../deps/cliffy.ts";
-import * as yaml from "https://deno.land/std@0.171.0/encoding/yaml.ts";
-import * as log from "https://deno.land/std@0.171.0/log/mod.ts";
-import * as path from "https://deno.land/std@0.171.0/path/mod.ts";
+import * as yaml from "https://deno.land/std@0.192.0/yaml/mod.ts";
+import * as log from "https://deno.land/std@0.192.0/log/mod.ts";
+import * as path from "https://deno.land/std@0.192.0/path/mod.ts";
 
 import { Configuration } from "../config.ts";
 import {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,5 @@
 import { TaskConfig } from "./task.ts";
-import * as yaml from "https://deno.land/std@0.171.0/encoding/yaml.ts";
+import * as yaml from "https://deno.land/std@0.192.0/yaml/mod.ts";
 import { findApexConfig } from "./utils.ts";
 import { log } from "./deps/log.ts";
 
@@ -15,11 +15,12 @@ export interface Configuration {
   tasks?: Record<string, TaskDefinition>;
 }
 
-export type TaskDefinition = string[] | TaskConfig;
+export type TaskDefinition = TaskConfig;
 
 export interface Target {
   module: string;
   visitorClass?: string;
+  scaffold?: boolean;
   ifNotExists?: boolean;
   append?: Visitor[];
   executable?: boolean;

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,10 +12,8 @@ export interface Configuration {
   config?: Config;
   plugins?: string[];
   generates?: Record<string, Target>;
-  tasks?: Record<string, TaskDefinition>;
+  tasks?: Record<string, TaskConfig>;
 }
-
-export type TaskDefinition = TaskConfig;
 
 export interface Target {
   module: string;

--- a/src/deps/dax.ts
+++ b/src/deps/dax.ts
@@ -1,0 +1,1 @@
+export * from "https://deno.land/x/dax@0.32.0/mod.ts";

--- a/src/deps/log.ts
+++ b/src/deps/log.ts
@@ -1,1 +1,1 @@
-export * as log from "https://deno.land/std@0.171.0/log/mod.ts";
+export * as log from "https://deno.land/std@0.192.0/log/mod.ts";

--- a/src/formatters.ts
+++ b/src/formatters.ts
@@ -81,6 +81,5 @@ async function exec(cmd: string, ...args: string[]) {
   const command = new Deno.Command(cmd, {
     args: args,
   });
-  const child = command.spawn();
-  await child.status;
+  await command.output();
 }

--- a/src/init.ts
+++ b/src/init.ts
@@ -91,22 +91,19 @@ export async function getTemplateSources(
   const tmpDir = await Deno.makeTempDir();
 
   log.debug(`Using template from path '${template}'`);
-  const cmd = [
-    "git",
+  const cmdArgs = [
     "clone",
     `--depth=1`,
   ];
   if (options.branch) {
-    cmd.push(`--branch=${options.branch}`);
+    cmdArgs.push(`--branch=${options.branch}`);
   }
-  cmd.push(...[template, tmpDir]);
+  cmdArgs.push(...[template, tmpDir]);
 
-  const process = Deno.run({
-    cmd,
-  });
-  const status = await process.status();
-  process.close();
-  if (!status.success) {
+  const command = new Deno.Command("git", { args: cmdArgs });
+  const result = await command.output();
+  // comprocessmand.close();
+  if (!result.success) {
     throw new Error(`Failed to clone template ${template}`);
   }
   const realTemplateDir = path.join(tmpDir, options.path || "");

--- a/src/init.ts
+++ b/src/init.ts
@@ -1,7 +1,7 @@
-import * as path from "https://deno.land/std@0.171.0/path/mod.ts";
-import * as fs from "https://deno.land/std@0.171.0/fs/mod.ts";
-import * as yaml from "https://deno.land/std@0.171.0/encoding/yaml.ts";
-import * as log from "https://deno.land/std@0.171.0/log/mod.ts";
+import * as path from "https://deno.land/std@0.192.0/path/mod.ts";
+import * as fs from "https://deno.land/std@0.192.0/fs/mod.ts";
+import * as yaml from "https://deno.land/std@0.192.0/yaml/mod.ts";
+import * as log from "https://deno.land/std@0.192.0/log/mod.ts";
 import {
   Confirm,
   ConfirmOptions,

--- a/src/init.ts
+++ b/src/init.ts
@@ -91,16 +91,16 @@ export async function getTemplateSources(
   const tmpDir = await Deno.makeTempDir();
 
   log.debug(`Using template from path '${template}'`);
-  const cmdArgs = [
+  const args = [
     "clone",
     `--depth=1`,
   ];
   if (options.branch) {
-    cmdArgs.push(`--branch=${options.branch}`);
+    args.push(`--branch=${options.branch}`);
   }
-  cmdArgs.push(...[template, tmpDir]);
+  args.push(...[template, tmpDir]);
 
-  const command = new Deno.Command("git", { args: cmdArgs });
+  const command = new Deno.Command("git", { args: args });
   const result = await command.output();
   // comprocessmand.close();
   if (!result.success) {

--- a/src/install.ts
+++ b/src/install.ts
@@ -1,4 +1,4 @@
-import * as log from "https://deno.land/std@0.171.0/log/mod.ts";
+import * as log from "https://deno.land/std@0.192.0/log/mod.ts";
 
 import { getTemplateInfo, ProcessOptions, processTemplate } from "./process.ts";
 import { makeRelativeUrl } from "./utils.ts";

--- a/src/process.ts
+++ b/src/process.ts
@@ -32,20 +32,20 @@ export async function process(
 
   // Run the generation process with restricted permissions.
   const href = new URL("./generate.ts", import.meta.url).href;
-  const cmdArgs = [
+  const args = [
     "run",
     "--allow-read",
     "--allow-net=deno.land,raw.githubusercontent.com",
   ];
   if (options.reload) {
-    cmdArgs.push("--reload");
+    args.push("--reload");
   }
-  cmdArgs.push(href);
+  args.push(href);
   if (options.scaffold) {
-    cmdArgs.push("--scaffold");
+    args.push("--scaffold");
   }
   const command = new Deno.Command("deno", {
-    args: cmdArgs,
+    args: args,
     stdout: "piped",
     stderr: "piped",
     stdin: "piped",
@@ -194,22 +194,22 @@ async function processGeneric<I, O>(
   // Run the generation process with restricted permissions.
   const href = new URL(url, import.meta.url).href;
 
-  const cmdArgs = [
+  const args = [
     "run",
     "--allow-read",
     "--allow-net=deno.land,raw.githubusercontent.com",
   ];
   if (options.reload) {
-    cmdArgs.push("--reload");
+    args.push("--reload");
   }
-  cmdArgs.push(href);
+  args.push(href);
   if (options.scaffold) {
-    cmdArgs.push("--scaffold");
+    args.push("--scaffold");
   }
 
   const command = new Deno.Command("deno", {
     cwd: Deno.cwd(),
-    args: cmdArgs,
+    args: args,
     stdout: "piped",
     stderr: "piped",
     stdin: "piped",

--- a/src/process.ts
+++ b/src/process.ts
@@ -1,8 +1,8 @@
 // deno-lint-ignore-file no-explicit-any
-import * as log from "https://deno.land/std@0.171.0/log/mod.ts";
-import * as path from "https://deno.land/std@0.171.0/path/mod.ts";
+import * as log from "https://deno.land/std@0.192.0/log/mod.ts";
+import * as path from "https://deno.land/std@0.192.0/path/mod.ts";
 import { fileExtension } from "https://deno.land/x/file_extension@v2.1.0/mod.ts";
-import * as base64 from "https://deno.land/std@0.171.0/encoding/base64.ts";
+import * as base64 from "https://deno.land/std@0.192.0/encoding/base64.ts";
 
 const __dirname = new URL(".", import.meta.url).pathname;
 
@@ -21,6 +21,7 @@ import { asBytes, asString } from "./utils.ts";
 
 export interface ProcessOptions {
   reload?: boolean;
+  scaffold?: boolean;
 }
 
 export async function process(
@@ -41,6 +42,9 @@ export async function process(
     cmd.push("--reload");
   }
   cmd.push(href);
+  if (options.scaffold) {
+    cmd.push("--scaffold");
+  }
   const p = await Deno.run({
     cmd,
     stdout: "piped",
@@ -199,6 +203,9 @@ async function processGeneric<I, O>(
     cmd.push("--reload");
   }
   cmd.push(href);
+  if (options.scaffold) {
+    cmd.push("--scaffold");
+  }
 
   const p = await Deno.run({
     cwd: Deno.cwd(),

--- a/src/process.ts
+++ b/src/process.ts
@@ -32,36 +32,38 @@ export async function process(
 
   // Run the generation process with restricted permissions.
   const href = new URL("./generate.ts", import.meta.url).href;
-  const cmd = [
-    "deno",
+  const cmdArgs = [
     "run",
     "--allow-read",
     "--allow-net=deno.land,raw.githubusercontent.com",
   ];
   if (options.reload) {
-    cmd.push("--reload");
+    cmdArgs.push("--reload");
   }
-  cmd.push(href);
+  cmdArgs.push(href);
   if (options.scaffold) {
-    cmd.push("--scaffold");
+    cmdArgs.push("--scaffold");
   }
-  const p = await Deno.run({
-    cmd,
+  const command = new Deno.Command("deno", {
+    args: cmdArgs,
     stdout: "piped",
     stderr: "piped",
     stdin: "piped",
   });
+  const p = command.spawn();
 
   const input = JSON.stringify(config);
-  await p.stdin.write(new TextEncoder().encode(input));
-  p.stdin.close();
+  const writer = p.stdin.getWriter();
+  await writer.write(new TextEncoder().encode(input));
+  await writer.close();
 
   // Reading the outputs and closes their pipes
-  const rawOutput = await p.output();
-  const rawError = await p.stderrOutput();
+  const out = await p.output();
+  const rawOutput = out.stdout;
+  const rawError = out.stderr;
 
-  const { code } = await p.status();
-  p.close();
+  const { code } = await p.status;
+  // p.close();
 
   const errorString = new TextDecoder().decode(rawError);
 
@@ -150,8 +152,7 @@ export async function writeOutput(generated: Output): Promise<void> {
         args: args,
         cwd: cmdConfig.dir,
       });
-      const child = command.spawn();
-      await child.status;
+      await command.output();
     });
   }
 }
@@ -193,38 +194,40 @@ async function processGeneric<I, O>(
   // Run the generation process with restricted permissions.
   const href = new URL(url, import.meta.url).href;
 
-  const cmd = [
-    "deno",
+  const cmdArgs = [
     "run",
     "--allow-read",
     "--allow-net=deno.land,raw.githubusercontent.com",
   ];
   if (options.reload) {
-    cmd.push("--reload");
+    cmdArgs.push("--reload");
   }
-  cmd.push(href);
+  cmdArgs.push(href);
   if (options.scaffold) {
-    cmd.push("--scaffold");
+    cmdArgs.push("--scaffold");
   }
 
-  const p = await Deno.run({
+  const command = new Deno.Command("deno", {
     cwd: Deno.cwd(),
-    cmd,
+    args: cmdArgs,
     stdout: "piped",
     stderr: "piped",
     stdin: "piped",
   });
+  const p = command.spawn();
 
   const input = JSON.stringify(config);
-  await p.stdin.write(new TextEncoder().encode(input));
-  p.stdin.close();
+  const writer = p.stdin.getWriter();
+  await writer.write(new TextEncoder().encode(input));
+  await writer.close();
 
   // Reading the outputs and closes their pipes
-  const rawOutput = await p.output();
-  const rawError = await p.stderrOutput();
+  const out = await p.output();
+  const rawOutput = out.stdout;
+  const rawError = out.stderr;
 
-  const { code } = await p.status();
-  p.close();
+  const { code } = await p.status;
+  // p.close();
 
   const errorString = new TextDecoder().decode(rawError);
 

--- a/src/run_config.ts
+++ b/src/run_config.ts
@@ -1,5 +1,5 @@
-import * as streams from "https://deno.land/std@0.171.0/streams/read_all.ts";
-import * as base64 from "https://deno.land/std@0.171.0/encoding/base64.ts";
+import * as streams from "https://deno.land/std@0.192.0/streams/read_all.ts";
+import * as base64 from "https://deno.land/std@0.192.0/encoding/base64.ts";
 
 import { Configuration } from "./config.ts";
 import { processConfig } from "./generate.ts";
@@ -8,10 +8,11 @@ import { processConfig } from "./generate.ts";
 if (!Deno.isatty(Deno.stdin.rid) && import.meta.main) {
   const stdinContent = await streams.readAll(Deno.stdin);
   const content = new TextDecoder().decode(stdinContent);
+  const scaffold = Deno.args.indexOf("--scaffold") != -1;
   try {
     const config = JSON.parse(content) as Configuration;
     console.log(JSON.stringify(
-      await processConfig(config),
+      await processConfig(config, scaffold),
       (_, v) => v instanceof Uint8Array ? base64.encode(v) : v,
     ));
   } catch (e) {

--- a/src/run_plugins.ts
+++ b/src/run_plugins.ts
@@ -1,5 +1,5 @@
-import * as streams from "https://deno.land/std@0.171.0/streams/read_all.ts";
-import * as base64 from "https://deno.land/std@0.171.0/encoding/base64.ts";
+import * as streams from "https://deno.land/std@0.192.0/streams/read_all.ts";
+import * as base64 from "https://deno.land/std@0.192.0/encoding/base64.ts";
 
 import { Configuration } from "./config.ts";
 import { processPlugins } from "./generate.ts";

--- a/src/run_process_template.ts
+++ b/src/run_process_template.ts
@@ -1,4 +1,4 @@
-import * as streams from "https://deno.land/std@0.171.0/streams/read_all.ts";
+import * as streams from "https://deno.land/std@0.192.0/streams/read_all.ts";
 
 import { ProcessTemplateArgs } from "./config.ts";
 import { importTemplate } from "./generate.ts";

--- a/src/run_template_info.ts
+++ b/src/run_template_info.ts
@@ -1,4 +1,4 @@
-import * as streams from "https://deno.land/std@0.171.0/streams/read_all.ts";
+import * as streams from "https://deno.land/std@0.192.0/streams/read_all.ts";
 
 import { importTemplate } from "./generate.ts";
 

--- a/src/task.ts
+++ b/src/task.ts
@@ -1,4 +1,4 @@
-import { build$, CommandBuilder } from "https://deno.land/x/dax@0.24.1/mod.ts";
+import { build$, CommandBuilder } from "./deps/dax.ts";
 
 export enum TaskRunner {
   Dax = "dax",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,7 @@
-import * as path from "https://deno.land/std@0.171.0/path/mod.ts";
+import * as path from "https://deno.land/std@0.192.0/path/mod.ts";
 import home_dir from "https://deno.land/x/dir@1.5.1/home_dir/mod.ts";
-import * as yaml from "https://deno.land/std@0.171.0/encoding/yaml.ts";
-import * as log from "https://deno.land/std@0.171.0/log/mod.ts";
+import * as yaml from "https://deno.land/std@0.192.0/yaml/mod.ts";
+import * as log from "https://deno.land/std@0.192.0/log/mod.ts";
 import * as apex from "https://deno.land/x/apex_core@v0.1.3/mod.ts";
 
 import {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,6 +1,6 @@
-import { assertEquals } from "https://deno.land/std@0.171.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.192.0/testing/asserts.ts";
 import { process } from "../src/process.ts";
-import * as path from "https://deno.land/std@0.171.0/path/mod.ts";
+import * as path from "https://deno.land/std@0.192.0/path/mod.ts";
 import { asBytes } from "../src/utils.ts";
 
 const __dirname = new URL(".", import.meta.url).pathname;

--- a/test/fixtures/task-apex-env.yaml
+++ b/test/fixtures/task-apex-env.yaml
@@ -3,4 +3,5 @@ config:
   some_val: 12345
 tasks:
   test:
-    - echo My spec is $apex_spec and some_val is $apex_config_some_val
+    cmds:
+      - echo My spec is $apex_spec and some_val is $apex_config_some_val

--- a/test/fixtures/task-deps.yaml
+++ b/test/fixtures/task-deps.yaml
@@ -5,4 +5,5 @@ tasks:
     cmds:
       - echo Hello World
   b:
-    - echo "From b"
+    cmds:
+      - echo "From b"

--- a/test/fixtures/task-env-vars.yaml
+++ b/test/fixtures/task-env-vars.yaml
@@ -1,4 +1,5 @@
 spec: ''
 tasks:
   test:
-    - echo Hello $NAME
+    cmds:
+      - echo Hello $NAME

--- a/test/fixtures/task-explicit.yaml
+++ b/test/fixtures/task-explicit.yaml
@@ -6,4 +6,5 @@ tasks:
     deps:
       - b
   b:
-    - echo "From b"
+    cmds:
+      - echo "From b"

--- a/test/fixtures/task-hello-world.yaml
+++ b/test/fixtures/task-hello-world.yaml
@@ -1,4 +1,5 @@
 spec: ''
 tasks:
   test:
-    - echo Hello World
+    cmds:
+      - echo Hello World

--- a/test/fixtures/task-refs.yaml
+++ b/test/fixtures/task-refs.yaml
@@ -5,5 +5,6 @@ tasks:
     cmds:
       - echo Hello World
   c: &c
-    - 'echo From c'
+    cmds:
+      - 'echo From c'
   b: *c

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -1,6 +1,6 @@
-import { assertEquals } from "https://deno.land/std@0.171.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.192.0/testing/asserts.ts";
 import { getTemplateSources, getUnresolved } from "../src/init.ts";
-import * as path from "https://deno.land/std@0.171.0/path/mod.ts";
+import * as path from "https://deno.land/std@0.192.0/path/mod.ts";
 import { asBytes, setupLogger } from "../src/utils.ts";
 import { Variable } from "../src/config.ts";
 

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -1,7 +1,7 @@
 import * as apex from "https://deno.land/x/apex_core@v0.1.3/mod.ts";
-import { assertEquals } from "https://deno.land/std@0.171.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.192.0/testing/asserts.ts";
 import { processConfig, processPlugin } from "../src/generate.ts";
-import * as path from "https://deno.land/std@0.171.0/path/mod.ts";
+import * as path from "https://deno.land/std@0.192.0/path/mod.ts";
 import { asBytes, setupLogger } from "../src/utils.ts";
 import { Configuration } from "../src/config.ts";
 
@@ -36,7 +36,12 @@ Deno.test(
       spec,
       config: { name: "", value: "original" },
       plugins: [plugin],
-      tasks: { "build": [`echo "overridden"`], dependency: [""] },
+      tasks: {
+        "build": {
+          cmds: [`echo "overridden"`],
+          deps: [""],
+        },
+      },
       generates: { "Test.1.file": { module: "overridden.ts" } },
     } as Configuration);
 
@@ -44,7 +49,7 @@ Deno.test(
       spec,
       config: { value: "original", name: "from-plugin" },
       plugins: [plugin],
-      tasks: { "build": [`echo "overridden"`], dependency: [""] },
+      tasks: { "build": { cmds: [`echo "overridden"`], deps: [""] } },
       generates: { "Test.1.file": { module: "overridden.ts" } },
     });
   },
@@ -67,7 +72,7 @@ Deno.test(
     });
 
     assertEquals(config.tasks, {
-      "build": [`echo "from-plugin"`],
+      "build": { cmds: [`echo "from-plugin"`] },
     });
   },
 );

--- a/test/raw-commands.test.ts
+++ b/test/raw-commands.test.ts
@@ -1,7 +1,4 @@
-import {
-  assert,
-  assertEquals,
-} from "https://deno.land/std@0.171.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.192.0/testing/asserts.ts";
 import { runApex } from "./run-apex.ts";
 
 Deno.test(

--- a/test/regression.test.ts
+++ b/test/regression.test.ts
@@ -1,14 +1,11 @@
 import * as apex from "https://deno.land/x/apex_core@v0.1.3/mod.ts";
-import { assertEquals } from "https://deno.land/std@0.171.0/testing/asserts.ts";
-import { processConfig, processPlugin } from "../src/generate.ts";
-import * as path from "https://deno.land/std@0.171.0/path/mod.ts";
-import { asBytes, setupLogger } from "../src/utils.ts";
-import { Configuration } from "../src/config.ts";
+import { assertEquals } from "https://deno.land/std@0.192.0/testing/asserts.ts";
+import { processPlugin } from "../src/generate.ts";
+import * as path from "https://deno.land/std@0.192.0/path/mod.ts";
+import { setupLogger } from "../src/utils.ts";
 
 const __dirname = new URL(".", import.meta.url).pathname;
 const spec = path.join(__dirname, "test.axdl");
-const plugin = path.join(__dirname, "test-plugin.ts");
-const generator = path.join(__dirname, "test-generator.ts");
 await setupLogger("DEBUG");
 
 Deno.test(

--- a/test/run-apex.ts
+++ b/test/run-apex.ts
@@ -2,26 +2,25 @@ export async function runApex(
   args: string[],
   env: Record<string, string> = {},
 ): Promise<Uint8Array> {
-  const cmd = [
-    "deno",
+  const cmdArgs = [
     "run",
     "--allow-all",
     "--unstable",
     "./apex.ts",
   ];
-  cmd.push(...args);
-  console.log(`Running: ${cmd.join(" ")}`);
+  cmdArgs.push(...args);
+  console.log(`Running: ${cmdArgs.join(" ")}`);
   env ||= {};
   // Leave in for quick debugging. Enabling debug logging for every test
   // causes problems for tests that assert on apex output.
   // env.APEX_LOG = "debug";
-  const proc = Deno.run({
+  const command = new Deno.Command("deno", {
     env,
     stderr: "inherit",
     stdout: "piped",
-    cmd,
+    args: cmdArgs,
   });
-  const out = await proc.output();
-  await proc.close();
-  return out;
+  const out = await command.output();
+
+  return out.stdout;
 }

--- a/test/run-apex.ts
+++ b/test/run-apex.ts
@@ -9,7 +9,7 @@ export async function runApex(
     "./apex.ts",
   ];
   cmdArgs.push(...args);
-  console.log(`Running: ${cmdArgs.join(" ")}`);
+  console.log(`Running: deno ${cmdArgs.join(" ")}`);
   env ||= {};
   // Leave in for quick debugging. Enabling debug logging for every test
   // causes problems for tests that assert on apex output.

--- a/test/run.test.ts
+++ b/test/run.test.ts
@@ -1,13 +1,13 @@
 import {
   assert,
   assertEquals,
-} from "https://deno.land/std@0.171.0/testing/asserts.ts";
+} from "https://deno.land/std@0.192.0/testing/asserts.ts";
 import { runTasks } from "../src/commands/run.ts";
 import { Task } from "../src/task.ts";
 import { runApex } from "./run-apex.ts";
 const __dirname = new URL(".", import.meta.url).pathname;
 
-async function runFixture(
+function runFixture(
   config: string,
   task: string,
   env: Record<string, string> = {},
@@ -35,7 +35,7 @@ function strEnc(str: string): Uint8Array {
 Deno.test(
   "no tasks defined",
   async () => {
-    const output = await runTasks({ spec: "" }, {}, []);
+    const _output = await runTasks({ spec: "" }, {}, []);
     assert(true, "should not throw");
   },
 );

--- a/test/run.test.ts
+++ b/test/run.test.ts
@@ -77,9 +77,11 @@ Deno.test(
   { permissions: { read: true, run: true, env: true } },
   async () => {
     try {
-      const output = await new Task({ cmds: ["DOES_NOT_EXIST"] }).run()!;
+      await new Task({ cmds: ["DOES_NOT_EXIST"] }).run()!;
       assert(false, "should throw");
-    } catch {}
+    } catch {
+      // Ignored
+    }
   },
 );
 

--- a/test/tasks.test.ts
+++ b/test/tasks.test.ts
@@ -1,30 +1,12 @@
-import { assertEquals } from "https://deno.land/std@0.171.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.192.0/testing/asserts.ts";
 import { loadTasks, parseTasks } from "../src/commands/run.ts";
 import { Task, TaskRunner } from "../src/task.ts";
-import * as path from "https://deno.land/std@0.171.0/path/mod.ts";
+import * as path from "https://deno.land/std@0.192.0/path/mod.ts";
 import { setupLogger } from "../src/utils.ts";
 
 const __dirname = new URL(".", import.meta.url).pathname;
 const plugin = path.join(__dirname, "test-plugin.ts");
 await setupLogger("DEBUG");
-
-Deno.test(
-  "run task array shorthand",
-  async () => {
-    const tasks = await parseTasks({
-      spec: "",
-      tasks: { start: [`echo "test"`] },
-    });
-
-    assertEquals(tasks, {
-      "start": new Task({
-        cmds: [`echo "test"`],
-        deps: [],
-        runner: TaskRunner.Dax,
-      }),
-    });
-  },
-);
 
 Deno.test(
   "tasks from plugin don't override original tasks",
@@ -34,7 +16,7 @@ Deno.test(
       tasks: {
         // note: the extra whitespace in 'build ' is intentional.
         "build ": { cmds: [`echo "original"`], deps: ["dep"] },
-        dep: [],
+        "dep ": {},
       },
     }, { reload: false });
 

--- a/test/template.test.ts
+++ b/test/template.test.ts
@@ -1,6 +1,6 @@
-import { assertEquals } from "https://deno.land/std@0.171.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.192.0/testing/asserts.ts";
 import { processTemplate } from "../src/process.ts";
-import * as path from "https://deno.land/std@0.171.0/path/mod.ts";
+import * as path from "https://deno.land/std@0.192.0/path/mod.ts";
 
 const __dirname = new URL(".", import.meta.url).pathname;
 

--- a/test/test-plugin.ts
+++ b/test/test-plugin.ts
@@ -1,6 +1,6 @@
 import { Configuration } from "../src/config.ts";
 import * as apex from "https://deno.land/x/apex_core@v0.1.3/mod.ts";
-import * as path from "https://deno.land/std@0.171.0/path/mod.ts";
+import * as path from "https://deno.land/std@0.192.0/path/mod.ts";
 
 const __dirname = new URL(".", import.meta.url).pathname;
 const generator = path.join(__dirname, "test-generator.ts");
@@ -24,7 +24,9 @@ export default function (
   config.config.name = "from-plugin";
 
   config.tasks ||= {};
-  config.tasks["build"] = [`echo "from-plugin"`];
+  config.tasks["build"] = {
+    cmds: [`echo "from-plugin"`],
+  };
 
   return config;
 }

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@0.171.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.192.0/testing/asserts.ts";
 import { Configuration } from "../src/config.ts";
 import { flatten, merge, mergeConfigurations } from "../src/utils.ts";
 
@@ -32,7 +32,7 @@ Deno.test(
         "original.txt": { module: "original.ts" },
       },
       tasks: {
-        original: ["echo 'original'"],
+        original: { cmds: ["echo 'original'"] },
       },
     };
     const plugin: Configuration = {
@@ -42,7 +42,7 @@ Deno.test(
         "plugin.txt": { module: "plugin.ts" },
       },
       tasks: {
-        original: ["echo 'plugin'"],
+        original: { cmds: ["echo 'plugin'"] },
       },
     };
 
@@ -55,7 +55,7 @@ Deno.test(
         "plugin.txt": { module: "plugin.ts" },
       },
       tasks: {
-        original: ["echo 'original'"],
+        original: { cmds: ["echo 'original'"] },
       },
     });
   },


### PR DESCRIPTION
This PR adds the `--scaffold` option to `apex generate`. This option allows an Apex configuration (and plugins) to defer generation of "scaffolded" files until the Apex spec is ready. This is important because once scaffolded files are generated, they cannot be regenerated because the developer would lose their changes.

Config example

```yaml
generates:
  my_service.go:
    ifNotExists: true
    scaffold: true
    module: 'https://deno.land/x/apex_codegen@v0.1.9/go/mod.ts'
    visitorClass: ScaffoldVisitor
```

The developer runs `apex generate --scaffold` to include the generation of these files.

Other miscellaneous improvements:
* Version bumps for std and dax
* Removed dead code and fixed tests with remnants of shorthand tasks
* Fixed bug where tables were being rendered twice